### PR TITLE
Generate Conformance Data with Alchemy

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/access-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/access-control-cluster.xml
@@ -113,29 +113,58 @@ limitations under the License.
       <description>ACL</description>
       <access op="read" privilege="administer"/>
       <access op="write" privilege="administer"/>
+      <mandatoryConform/>
     </attribute>
 
     <attribute side="server" code="0x0001" define="EXTENSION" type="array" entryType="AccessControlExtensionStruct" writable="true" optional="true">
       <description>Extension</description>
       <access op="read" privilege="administer"/>
       <access op="write" privilege="administer"/>
+      <mandatoryConform>
+        <feature name="EXTS"/>
+      </mandatoryConform>
     </attribute>
 
-    <attribute side="server" code="0x0002" define="SUBJECTS_PER_ACCESS_CONTROL_ENTRY" type="int16u" min="4" default="4">SubjectsPerAccessControlEntry</attribute>
-    <attribute side="server" code="0x0003" define="TARGETS_PER_ACCESS_CONTROL_ENTRY" type="int16u" min="3" default="3">TargetsPerAccessControlEntry</attribute>
-    <attribute side="server" code="0x0004" define="ACCESS_CONTROL_ENTRIES_PER_FABRIC" type="int16u" min="4" default="4">AccessControlEntriesPerFabric</attribute>
-    <attribute code="0x0005" side="server" define="COMMISSIONING_ARL" type="array" entryType="CommissioningAccessRestrictionEntryStruct" optional="true">CommissioningARL</attribute>
-    <attribute code="0x0006" side="server" define="ARL" type="array" entryType="AccessRestrictionEntryStruct" optional="true">ARL</attribute>
-
+    <attribute side="server" code="0x0002" define="SUBJECTS_PER_ACCESS_CONTROL_ENTRY" type="int16u" min="4" default="4">
+      <description>SubjectsPerAccessControlEntry</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="TARGETS_PER_ACCESS_CONTROL_ENTRY" type="int16u" min="3" default="3">
+      <description>TargetsPerAccessControlEntry</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0004" define="ACCESS_CONTROL_ENTRIES_PER_FABRIC" type="int16u" min="4" default="4">
+      <description>AccessControlEntriesPerFabric</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute code="0x0005" side="server" define="COMMISSIONING_ARL" type="array" entryType="CommissioningAccessRestrictionEntryStruct" optional="true">
+      <description>CommissioningARL</description>
+      <mandatoryConform>
+        <feature name="MNGD"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute code="0x0006" side="server" define="ARL" type="array" entryType="AccessRestrictionEntryStruct" optional="true">
+      <description>ARL</description>
+      <mandatoryConform>
+        <feature name="MNGD"/>
+      </mandatoryConform>
+    </attribute>
+    
     <command code="0x00" source="client" name="ReviewFabricRestrictions" isFabricScoped="true" optional="true" response="ReviewFabricRestrictionsResponse">
       <description>This command signals to the service associated with the device vendor that the fabric administrator would like a review of the current restrictions on the accessing fabric.</description>
        <access op="invoke" privilege="administer"/>
       <arg id="0" name="ARL" array="true" type="CommissioningAccessRestrictionEntryStruct"/>
-     </command>
+      <mandatoryConform>
+        <feature name="MNGD"/>
+      </mandatoryConform>
+    </command>
 
     <command code="0x01" source="server" name="ReviewFabricRestrictionsResponse" optional="true" disableDefaultResponse="true">
       <description>Returns the review token for the request, which can be used to correlate with a FabricRestrictionReviewUpdate event.</description>
       <arg id="0" name="Token" type="int64u"/>
+      <mandatoryConform>
+        <feature name="MNGD"/>
+      </mandatoryConform>
     </command>
 
     <event side="server" code="0x0000" name="AccessControlEntryChanged" priority="info" isFabricSensitive="true">
@@ -145,6 +174,7 @@ limitations under the License.
       <field id="3" name="ChangeType" type="ChangeTypeEnum" min="0x00" max="0x02"/>
       <field id="4" name="LatestValue" type="AccessControlEntryStruct" isNullable="true"/>
       <access op="read" privilege="administer"/>
+      <mandatoryConform/>
     </event>
 
     <event side="server" code="0x0001" name="AccessControlExtensionChanged" priority="info" isFabricSensitive="true" optional="true">
@@ -154,6 +184,9 @@ limitations under the License.
       <field id="3" name="ChangeType" type="ChangeTypeEnum" min="0x00" max="0x02"/>
       <field id="4" name="LatestValue" type="AccessControlExtensionStruct" isNullable="true"/>
       <access op="read" privilege="administer"/>
+      <mandatoryConform>
+        <feature name="EXTS"/>
+      </mandatoryConform>
     </event>
 
     <event side="server" code="0x0002" name="FabricRestrictionReviewUpdate" priority="info" isFabricSensitive="true" optional="true">
@@ -162,6 +195,9 @@ limitations under the License.
       <field id="1" name="Instruction" type="long_char_string" optional="true" length="512"/>
       <field id="2" name="ARLRequestFlowUrl" type="long_char_string" optional="true" length="256"/>
       <access op="read" privilege="administer"/>
+      <mandatoryConform>
+        <feature name="MNGD"/>
+      </mandatoryConform>
     </event>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/account-login-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/account-login-cluster.xml
@@ -28,31 +28,36 @@ limitations under the License.
 
     <command source="client" code="0x00" name="GetSetupPIN" isFabricScoped="true" response="GetSetupPINResponse" mustUseTimedInvoke="true" optional="false">
       <description>Upon receipt, the Content App checks if the account associated with the client Temp Account Identifier Rotating ID is the same acount that is active on the given Content App. If the accounts are the same, then the Content App includes the Setup PIN in the GetSetupPIN Response.</description>
-      <access op="invoke" role="administer" />
+      <access op="invoke" role="administer"/>
       <arg name="TempAccountIdentifier" minLength="16" length="100" type="char_string"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x02" name="Login" isFabricScoped="true" mustUseTimedInvoke="true" optional="false">
       <description>Upon receipt, the Content App checks if the account associated with the client’s Temp Account Identifier (Rotating ID) has a current active Setup PIN with the given value. If the Setup PIN is valid for the user account associated with the Temp Account Identifier, then the Content App MAY make that user account active.</description>
-      <access op="invoke" role="administer" />
+      <access op="invoke" role="administer"/>
       <arg name="TempAccountIdentifier" minLength="16" length="100" type="char_string"/>
       <arg name="SetupPIN" minLength="8" type="char_string"/>
-      <arg name="Node" type="node_id" optional="true" />
+      <arg name="Node" type="node_id" optional="true"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x03" name="Logout" isFabricScoped="true" mustUseTimedInvoke="true" optional="false">
       <description>The purpose of this command is to instruct the Content App to clear the current user account. This command SHOULD be used by clients of a Content App to indicate the end of a user session.</description>
       <arg name="Node" type="node_id" optional="true"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x01" name="GetSetupPINResponse" optional="false" disableDefaultResponse="true">
       <description>This message is sent in response to the GetSetupPIN Request, and contains the Setup PIN code, or null when the accounts identified in the request does not match the active account of the running Content App.</description>
       <arg name="SetupPIN" type="char_string"/>
+      <mandatoryConform/>
     </command>
 
     <event side="server" code="0x00" priority="critical" name="LoggedOut" optional="false">
       <description>This event can be used by the Content App to indicate that the current user has logged out. In response to this event, the Fabric Admin SHALL remove access to this Content App by the specified Node. If no Node is provided, then the Fabric Admin SHALL remove access to all non-Admin Nodes.</description>
       <field id="0" name="Node" type="node_id" optional="true"/>
+      <optionalConform/>
     </event>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/actions-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/actions-cluster.xml
@@ -89,11 +89,20 @@ limitations under the License.
     <code>0x0025</code>
     <define>ACTIONS_CLUSTER</define>
     <description>This cluster provides a standardized way for a Node (typically a Bridge, but could be any Node) to expose action information.</description>
-
-    <attribute side="server" code="0x0000" define="ACTION_LIST" type="array" entryType="ActionStruct" length="256" writable="false" optional="false">ActionList</attribute>
-    <attribute side="server" code="0x0001" define="ENDPOINT_LIST" type="array" entryType="EndpointListStruct" length="256" writable="false" optional="false">EndpointLists</attribute>
-    <attribute side="server" code="0x0002" define="SETUP_URL" type="LONG_CHAR_STRING" length="512" writable="false" optional="true">SetupURL</attribute>
-
+    
+    <attribute side="server" code="0x0000" define="ACTION_LIST" type="array" entryType="ActionStruct" length="256">
+      <description>ActionList</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="ENDPOINT_LIST" type="array" entryType="EndpointListStruct" length="256">
+      <description>EndpointLists</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="SETUP_URL" type="LONG_CHAR_STRING" length="512" optional="true">
+      <description>SetupURL</description>
+      <optionalConform/>
+    </attribute>
+    
     <command source="client" code="0x00" name="InstantAction" optional="true">
       <description>This command triggers an action (state change) on the involved endpoints.</description>
       <arg name="ActionID" type="int16u"/>
@@ -173,17 +182,19 @@ limitations under the License.
 
     <event side="server" code="0x00" priority="info" name="StateChanged" optional="false">
       <description>This event SHALL be generated when there is a change in the Status of an ActionID.</description>
-      <field id="0" name="ActionID" type="int16u" />
-      <field id="1" name="InvokeID" type="int32u" />
+      <field id="0" name="ActionID" type="int16u"/>
+      <field id="1" name="InvokeID" type="int32u"/>
       <field id="2" name="NewState" type="ActionStateEnum" />
+      <mandatoryConform/>
     </event>
 
     <event side="server" code="0x01" priority="info" name="ActionFailed" optional="false">
       <description>This event SHALL be generated when there is some error which prevents the action from its normal planned execution.</description>
-      <field id="0" name="ActionID" type="int16u" />
-      <field id="1" name="InvokeID" type="int32u" />
-      <field id="2" name="NewState" type="ActionStateEnum" />
-      <field id="3" name="Error"    type="ActionErrorEnum" />
+      <field id="0" name="ActionID" type="int16u"/>
+      <field id="1" name="InvokeID" type="int32u"/>
+      <field id="2" name="NewState" type="ActionStateEnum"/>
+      <field id="3" name="Error"    type="ActionErrorEnum"/>
+      <mandatoryConform/>
     </event>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/administrator-commissioning-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/administrator-commissioning-cluster.xml
@@ -43,10 +43,19 @@ limitations under the License.
         <optionalConform/>
       </feature>
     </features>
-    <attribute side="server" code="0x0000" define="WINDOW_STATUS" type="CommissioningWindowStatusEnum" writable="false" optional="false">WindowStatus</attribute>
-    <attribute side="server" code="0x0001" define="ADMIN_FABRIC_INDEX" type="fabric_idx" writable="false" isNullable="true" optional="false">AdminFabricIndex</attribute>
-    <attribute side="server" code="0x0002" define="ADMIN_VENDOR_ID" type="vendor_id" writable="false" isNullable="true" optional="false">AdminVendorId</attribute>
-
+    <attribute side="server" code="0x0000" define="WINDOW_STATUS" type="CommissioningWindowStatusEnum">
+      <description>WindowStatus</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="ADMIN_FABRIC_INDEX" type="fabric_idx" isNullable="true">
+      <description>AdminFabricIndex</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="ADMIN_VENDOR_ID" type="vendor_id" isNullable="true">
+      <description>AdminVendorId</description>
+      <mandatoryConform/>
+    </attribute>
+    
     <command source="client" code="0x00" name="OpenCommissioningWindow" mustUseTimedInvoke="true" optional="false">
       <description>This command is used by a current Administrator to instruct a Node to go into commissioning mode using enhanced commissioning method.</description>
       <arg name="CommissioningTimeout" type="int16u"/>
@@ -55,17 +64,22 @@ limitations under the License.
       <arg name="Iterations" type="int32u"/>
       <arg name="Salt" type="octet_string" length="32"/>
       <access op="invoke" privilege="administer"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x01" name="OpenBasicCommissioningWindow" mustUseTimedInvoke="true" optional="true">
       <description>This command is used by a current Administrator to instruct a Node to go into commissioning mode using basic commissioning method, if the node supports it.</description>
       <arg name="CommissioningTimeout" type="int16u"/>
       <access op="invoke" privilege="administer"/>
+      <mandatoryConform>
+        <feature name="BC"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x02" name="RevokeCommissioning" mustUseTimedInvoke="true" optional="false">
       <description>This command is used by a current Administrator to instruct a Node to revoke any active Open Commissioning Window or Open Basic Commissioning Window command.</description>
       <access op="invoke" privilege="administer"/>
+      <mandatoryConform/>
     </command>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/air-quality-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/air-quality-cluster.xml
@@ -41,7 +41,10 @@ limitations under the License.
     </features>
 
     <!-- Attributes -->
-    <attribute side="server" code="0x0000" define="AIR_QUALITY" type="AirQualityEnum" min="0" max="6" writable="false" isNullable="false" default="0" optional="false">AirQuality</attribute>
+    <attribute side="server" code="0x0000" define="AIR_QUALITY" type="AirQualityEnum" min="0" max="6" default="0">
+      <description>AirQuality</description>
+      <mandatoryConform/>
+    </attribute>
   </cluster>
 
   <!-- Cluster Data Types -->

--- a/src/app/zap-templates/zcl/data-model/chip/application-basic-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/application-basic-cluster.xml
@@ -24,16 +24,38 @@ limitations under the License.
     <client init="false" tick="false">true</client>
     <server init="false" tick="false">true</server>
     <description>This cluster provides information about an application running on a TV or media player device which is represented as an endpoint.</description>
-    <attribute side="server" code="0x0000" define="APPLICATION_VENDOR_NAME"         type="char_string"                default=""     length="32"               writable="false" optional="true">VendorName</attribute>
-    <attribute side="server" code="0x0001" define="APPLICATION_VENDOR_ID"           type="vendor_id"                  default="0x0"  min="0x0000" max="0xFFFF" writable="false" optional="true">VendorID</attribute>
-    <attribute side="server" code="0x0002" define="APPLICATION_NAME"                type="long_char_string"           length="256"               writable="false" optional="false">ApplicationName</attribute>
-    <attribute side="server" code="0x0003" define="APPLICATION_PRODUCT_ID"          type="int16u"                     default="0x0"  min="0x0000" max="0xFFFF" writable="false" optional="true">ProductID</attribute>
-    <attribute side="server" code="0x0004" define="APPLICATION_APP"                 type="ApplicationStruct"                                                   writable="false" optional="false">Application</attribute>
-    <attribute side="server" code="0x0005" define="APPLICATION_STATUS"              type="ApplicationStatusEnum"      default="0x01" min="0x00"   max="0xFF"   writable="false" optional="false">Status</attribute>
-    <attribute side="server" code="0x0006" define="APPLICATION_VERSION"             type="char_string"                               length="32"               writable="false" optional="false">ApplicationVersion</attribute>
-    <attribute side="server" code="0x0007" define="APPLICATION_ALLOWED_VENDOR_LIST" type="array" entryType="vendor_id"               length="32"               writable="false" optional="false">
-        <description>AllowedVendorList</description>
-        <access op="read" role="administer"/>
+    <attribute side="server" code="0x0000" define="APPLICATION_VENDOR_NAME" type="char_string" length="32" optional="true">
+      <description>VendorName</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="APPLICATION_VENDOR_ID" type="vendor_id" optional="true">
+      <description>VendorID</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="APPLICATION_NAME" type="long_char_string" length="256">
+      <description>ApplicationName</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="APPLICATION_PRODUCT_ID" type="int16u" optional="true">
+      <description>ProductID</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0004" define="APPLICATION_APP" type="ApplicationStruct">
+      <description>Application</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0005" define="APPLICATION_STATUS" type="ApplicationStatusEnum" default="0x01" min="0x00" max="0xFF">
+      <description>Status</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0006" define="APPLICATION_VERSION" type="char_string" length="32">
+      <description>ApplicationVersion</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0007" define="APPLICATION_ALLOWED_VENDOR_LIST" type="array" entryType="vendor_id" length="32">
+      <description>AllowedVendorList</description>
+      <access op="read" role="administer"/>
+      <mandatoryConform/>
     </attribute>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/application-launcher-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/application-launcher-cluster.xml
@@ -31,29 +31,41 @@ limitations under the License.
       </feature>
     </features>
 
-    <attribute side="server" code="0x0000" define="APPLICATION_LAUNCHER_LIST"        type="array" entryType="int16u" reportable="true"  writable="false" optional="true">CatalogList</attribute>
-    <attribute side="server" code="0x0001" define="APPLICATION_LAUNCHER_CURRENT_APP" type="ApplicationEPStruct"      isNullable="true" writable="false"  optional="true">CurrentApp</attribute>
-
+    <attribute side="server" code="0x0000" define="APPLICATION_LAUNCHER_LIST" type="array" entryType="int16u" reportable="true" optional="true">
+      <description>CatalogList</description>
+      <mandatoryConform>
+        <feature name="AP"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="APPLICATION_LAUNCHER_CURRENT_APP" type="ApplicationEPStruct" isNullable="true" optional="true">
+      <description>CurrentApp</description>
+      <optionalConform/>
+    </attribute>
+    
     <command source="client" code="0x00" name="LaunchApp" response="LauncherResponse" optional="false">
       <description>Upon receipt, this SHALL launch the specified app with optional data. The TV Device SHALL launch and bring to foreground the identified application in the command if the application is not already launched and in foreground. The TV Device SHALL update state attribute on the Application Basic cluster of the Endpoint corresponding to the launched application. This command returns a Launch Response.</description>
       <arg name="Application" type="ApplicationStruct" optional="true"/>
       <arg name="Data"  type="octet_string" optional="true"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x01" name="StopApp" response="LauncherResponse" optional="false">
       <description>Upon receipt on a Video Player endpoint this SHALL stop the specified application if it is running.</description>
       <arg name="Application" type="ApplicationStruct" optional="true"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x02" name="HideApp" response="LauncherResponse" optional="false">
       <description>Upon receipt on a Video Player endpoint this SHALL hide the specified application if it is running and visible.</description>
       <arg name="Application" type="ApplicationStruct" optional="true"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x03" name="LauncherResponse" optional="false">
       <description>This command SHALL be generated in response to LaunchApp commands.</description>
       <arg name="Status" type="StatusEnum"/>
       <arg name="Data" type="octet_string" optional="true"/>
+      <mandatoryConform/>
     </command>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/audio-output-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/audio-output-cluster.xml
@@ -31,12 +31,19 @@ limitations under the License.
       </feature>
     </features>
 
-    <attribute side="server" code="0x0000" define="AUDIO_OUTPUT_LIST"           type="array" entryType="OutputInfoStruct" length="254"          writable="false"  optional="false">OutputList</attribute>
-    <attribute side="server" code="0x0001" define="AUDIO_OUTPUT_CURRENT_OUTPUT" type="int8u" default="0x00"               min="0x00" max="0xFF" writable="false"  optional="false">CurrentOutput</attribute>
-
+    <attribute side="server" code="0x0000" define="AUDIO_OUTPUT_LIST" type="array" entryType="OutputInfoStruct" length="254">
+      <description>OutputList</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="AUDIO_OUTPUT_CURRENT_OUTPUT" type="int8u">
+      <description>CurrentOutput</description>
+      <mandatoryConform/>
+    </attribute>
+    
     <command source="client" code="0x00" name="SelectOutput" optional="false">
       <description>Upon receipt, this SHALL change the output on the media device to the output at a specific index in the Output List.</description>
       <arg name="Index" type="int8u"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x01" name="RenameOutput" optional="true">
@@ -44,6 +51,9 @@ limitations under the License.
       <access op="invoke" role="manage" />
       <arg name="Index" type="int8u"/>
       <arg name="Name" type="char_string"/>
+      <mandatoryConform>
+        <feature name="NU"/>
+      </mandatoryConform>
     </command>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/ballast-configuration-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/ballast-configuration-cluster.xml
@@ -41,53 +41,75 @@ limitations under the License.
     <globalAttribute side="either" code="0xFFFD" value="4"/>
 
     <!-- Ballast Configuration Attribute Set -->
-    <attribute side="server" code="0x0000" define="PHYSICAL_MIN_LEVEL" type="int8u" min="0x01" max="0xFE" writable="false" default="0x01" optional="false">PhysicalMinLevel</attribute>
-    <attribute side="server" code="0x0001" define="PHYSICAL_MAX_LEVEL" type="int8u" min="0x01" max="0xFE" writable="false" default="0xFE" optional="false">PhysicalMaxLevel</attribute>
-    <attribute side="server" code="0x0002" define="BALLAST_STATUS" type="BallastStatusBitmap" min="0x00" max="0x03" writable="false" default="0x00" optional="true">BallastStatus</attribute>
-    <!-- Ballast Settings Attribute Set -->
-    <attribute side="server" code="0x0010" define="MIN_LEVEL" type="int8u" min="0x01" max="0xFE" writable="true" default="0x01" optional="false">
-        <description>MinLevel</description>
-        <access op="write" privilege="manage"/>
+    <attribute side="server" code="0x0000" define="PHYSICAL_MIN_LEVEL" type="int8u" min="0x01" max="0xFE" default="0x01">
+      <description>PhysicalMinLevel</description>
+      <mandatoryConform/>
     </attribute>
-    <attribute side="server" code="0x0011" define="MAX_LEVEL" type="int8u" min="0x01" max="0xFE" writable="true" default="0xFE" optional="false">
-        <description>MaxLevel</description>
-        <access op="write" privilege="manage"/>
+    <attribute side="server" code="0x0001" define="PHYSICAL_MAX_LEVEL" type="int8u" min="0x01" max="0xFE" default="0xFE">
+      <description>PhysicalMaxLevel</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="BALLAST_STATUS" type="BallastStatusBitmap" min="0x00" max="0x03" default="0x00" optional="true">
+      <description>BallastStatus</description>
+      <optionalConform/>
+    </attribute>
+    <!-- Ballast Settings Attribute Set -->
+    <attribute side="server" code="0x0010" define="MIN_LEVEL" type="int8u" min="0x01" max="0xFE" writable="true" default="0x01">
+      <description>MinLevel</description>
+      <access op="write" privilege="manage"/>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0011" define="MAX_LEVEL" type="int8u" min="0x01" max="0xFE" writable="true" default="0xFE">
+      <description>MaxLevel</description>
+      <access op="write" privilege="manage"/>
+      <mandatoryConform/>
     </attribute>
     <!-- PowerOnLevel and PowerOnFadeTime are deprecated -->
     <attribute side="server" code="0x0014" define="INTRINSIC_BALLAST_FACTOR" type="int8u" writable="true" isNullable="true" optional="true">
-        <description>IntrinsicBallastFactor</description>
-        <access op="write" privilege="manage"/>
+      <description>IntrinsicBallastFactor</description>
+      <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
-    <attribute side="server" code="0x0015" define="BALLAST_FACTOR_ADJUSTMENT" type="int8u" min="0x64" writable="true" default="0xFF" isNullable="true" optional="true">
-        <description>BallastFactorAdjustment</description>
-        <access op="write" privilege="manage"/>
+    <attribute side="server" code="0x0015" define="BALLAST_FACTOR_ADJUSTMENT" type="int8u" min="0x64" writable="true" isNullable="true" optional="true">
+      <description>BallastFactorAdjustment</description>
+      <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
     <!-- Lamp Information Attribute Set -->
-    <attribute side="server" code="0x0020" define="LAMP_QUANTITY" type="int8u" writable="false" optional="false">LampQuantity</attribute>
+    <attribute side="server" code="0x0020" define="LAMP_QUANTITY" type="int8u">
+      <description>LampQuantity</description>
+      <mandatoryConform/>
+    </attribute>
     <!-- Lamp Settings Attribute Set -->
     <attribute side="server" code="0x0030" define="LAMP_TYPE" type="char_string" length="16" writable="true" optional="true">
-        <description>LampType</description>
-        <access op="write" privilege="manage"/>
+      <description>LampType</description>
+      <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
     <attribute side="server" code="0x0031" define="LAMP_MANUFACTURER" type="char_string" length="16" writable="true" optional="true">
-        <description>LampManufacturer</description>
-        <access op="write" privilege="manage"/>
+      <description>LampManufacturer</description>
+      <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
-    <attribute side="server" code="0x0032" define="LAMP_RATED_HOURS" type="int24u" writable="true" default="0xFFFFFF" isNullable="true" optional="true">
-        <description>LampRatedHours</description>
-        <access op="write" privilege="manage"/>
+    <attribute side="server" code="0x0032" define="LAMP_RATED_HOURS" type="int24u" writable="true" isNullable="true" optional="true">
+      <description>LampRatedHours</description>
+      <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
     <attribute side="server" code="0x0033" define="LAMP_BURN_HOURS" type="int24u" writable="true" default="0x000000" isNullable="true" optional="true">
-        <description>LampBurnHours</description>
-        <access op="write" privilege="manage"/>
+      <description>LampBurnHours</description>
+      <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
     <attribute side="server" code="0x0034" define="LAMP_ALARM_MODE" type="LampAlarmModeBitmap" min="0x00" max="0x01" writable="true" default="0x00" optional="true">
-        <description>LampAlarmMode</description>
-        <access op="write" privilege="manage"/>
+      <description>LampAlarmMode</description>
+      <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
-    <attribute side="server" code="0x0035" define="LAMP_BURN_HOURS_TRIP_POINT" type="int24u" writable="true" default="0xFFFFFF" isNullable="true" optional="true">
-        <description>LampBurnHoursTripPoint</description>
-        <access op="write" privilege="manage"/>
+    <attribute side="server" code="0x0035" define="LAMP_BURN_HOURS_TRIP_POINT" type="int24u" writable="true" isNullable="true" optional="true">
+      <description>LampBurnHoursTripPoint</description>
+      <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/basic-information-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/basic-information-cluster.xml
@@ -74,52 +74,118 @@ limitations under the License.
       which apply to the whole Node. Also allows setting user device information such as location.</description>
     <globalAttribute side="either" code="0xFFFD" value="3"/>
 
-    <attribute side="server" code="0"  define="DATA_MODEL_REVISION"       type="int16u"                                                                             >DataModelRevision</attribute>
-    <attribute side="server" code="1"  define="VENDOR_NAME"               type="char_string"               length="32"                                              >VendorName</attribute>
-    <attribute side="server" code="2"  define="VENDOR_ID"                 type="vendor_id"                                                                          >VendorID</attribute>
-    <attribute side="server" code="3"  define="PRODUCT_NAME"              type="char_string"               length="32"                                              >ProductName</attribute>
-    <attribute side="server" code="4"  define="PRODUCT_ID"                type="int16u"                                                                             >ProductID</attribute>
-    <attribute side="server" code="5"  define="NODE_LABEL"                type="char_string"               length="32"  default=""   writable="true"                >
+    <attribute side="server" code="0" define="DATA_MODEL_REVISION" type="int16u">
+      <description>DataModelRevision</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="1" define="VENDOR_NAME" type="char_string" length="32">
+      <description>VendorName</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="2" define="VENDOR_ID" type="vendor_id">
+      <description>VendorID</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="3" define="PRODUCT_NAME" type="char_string" length="32">
+      <description>ProductName</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="4" define="PRODUCT_ID" type="int16u">
+      <description>ProductID</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="5" define="NODE_LABEL" type="char_string" length="32" writable="true">
       <description>NodeLabel</description>
       <access op="read" privilege="view"/>
       <access op="write" privilege="manage"/>
+      <mandatoryConform/>
     </attribute>
     <attribute side="server" code="6"  define="LOCATION"                  type="char_string"               length="2"   default="XX" writable="true"                >
       <description>Location</description>
       <access op="read" privilege="view"/>
       <access op="write" privilege="administer"/>
+      <mandatoryConform/>
     </attribute>
-    <attribute side="server" code="7"  define="HARDWARE_VERSION"          type="int16u"                                 default="0"                                 >HardwareVersion</attribute>
-    <attribute side="server" code="8"  define="HARDWARE_VERSION_STRING"   type="char_string" minLength="1" length="64"                                              >HardwareVersionString</attribute>
-    <attribute side="server" code="9"  define="SOFTWARE_VERSION"          type="int32u"                                 default="0"                                 >SoftwareVersion</attribute>
-    <attribute side="server" code="10" define="SOFTWARE_VERSION_STRING"   type="char_string" minLength="1" length="64"                                              >SoftwareVersionString</attribute>
-    <attribute side="server" code="11" define="MANUFACTURING_DATE"        type="char_string" minLength="8" length="16"                               optional="true">ManufacturingDate</attribute>
-    <attribute side="server" code="12" define="PART_NUMBER"               type="char_string"               length="32"                               optional="true">PartNumber</attribute>
-    <attribute side="server" code="13" define="PRODUCT_URL"               type="long_char_string"          length="256"                              optional="true">ProductURL</attribute>
-    <attribute side="server" code="14" define="PRODUCT_LABEL"             type="char_string"               length="64"                               optional="true">ProductLabel</attribute>
-    <attribute side="server" code="15" define="SERIAL_NUMBER"             type="char_string"               length="32"                               optional="true">SerialNumber</attribute>
-    <attribute side="server" code="16" define="LOCAL_CONFIG_DISABLED"     type="boolean"                                default="0"  writable="true" optional="true">
+    <attribute side="server" code="7" define="HARDWARE_VERSION" type="int16u" default="0">
+      <description>HardwareVersion</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="8" define="HARDWARE_VERSION_STRING" type="char_string" minLength="1" length="64">
+      <description>HardwareVersionString</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="9" define="SOFTWARE_VERSION" type="int32u" default="0">
+      <description>SoftwareVersion</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="10" define="SOFTWARE_VERSION_STRING" type="char_string" minLength="1" length="64">
+      <description>SoftwareVersionString</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="11" define="MANUFACTURING_DATE" type="char_string" minLength="8" length="16" optional="true">
+      <description>ManufacturingDate</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="12" define="PART_NUMBER" type="char_string" length="32" optional="true">
+      <description>PartNumber</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="13" define="PRODUCT_URL" type="long_char_string" length="256" optional="true">
+      <description>ProductURL</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="14" define="PRODUCT_LABEL" type="char_string" length="64" optional="true">
+      <description>ProductLabel</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="15" define="SERIAL_NUMBER" type="char_string" length="32" optional="true">
+      <description>SerialNumber</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="16" define="LOCAL_CONFIG_DISABLED" type="boolean" default="0" writable="true" optional="true">
       <description>LocalConfigDisabled</description>
       <access op="read" privilege="view"/>
       <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
-    <attribute side="server" code="17" define="REACHABLE"                 type="boolean"                                default="1"                  optional="true">Reachable</attribute>
-    <attribute side="server" code="18" define="UNIQUE_ID"                 type="char_string"               length="32"                               optional="false">UniqueID</attribute>
-    <attribute side="server" code="19" define="CAPABILITY_MINIMA"         type="CapabilityMinimaStruct"                              writable="false"               >CapabilityMinima</attribute>
-    <attribute side="server" code="20" define="PRODUCT_APPEARANCE"        type="ProductAppearanceStruct"                                             optional="true">ProductAppearance</attribute>
-    <attribute side="server" code="21" define="SPECIFICATION_VERSION"     type="int32u"                                                                             >SpecificationVersion</attribute>
-    <attribute side="server" code="22" define="MAX_PATHS_PER_INVOKE"      type="int16u"                                                                             >MaxPathsPerInvoke</attribute>
+    <attribute side="server" code="17" define="REACHABLE" type="boolean" default="1" optional="true">
+      <description>Reachable</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="18" define="UNIQUE_ID" type="char_string" length="32">
+      <description>UniqueID</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="19" define="CAPABILITY_MINIMA" type="CapabilityMinimaStruct">
+      <description>CapabilityMinima</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="20" define="PRODUCT_APPEARANCE" type="ProductAppearanceStruct" optional="true">
+      <description>ProductAppearance</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="21" define="SPECIFICATION_VERSION" type="int32u">
+      <description>SpecificationVersion</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="22" define="MAX_PATHS_PER_INVOKE" type="int16u">
+      <description>MaxPathsPerInvoke</description>
+      <mandatoryConform/>
+    </attribute>
 
     <event side="server" code="0x00" name="StartUp" priority="critical" optional="false">
       <description>The StartUp event SHALL be emitted by a Node as soon as reasonable after completing a boot or reboot process.</description>
       <field id="0" name="SoftwareVersion" type="int32u"/>
+      <mandatoryConform/>
     </event>
     <event side="server" code="0x01" name="ShutDown" priority="critical" optional="true">
       <description>The ShutDown event SHOULD be emitted by a Node prior to any orderly shutdown sequence on a best-effort basis.</description>
+      <optionalConform/>
     </event>
     <event side="server" code="0x02" name="Leave" priority="info" optional="true">
       <description>The Leave event SHOULD be emitted by a Node prior to permanently leaving the Fabric.</description>
       <field id="0" name="FabricIndex" type="fabric_idx"/>
+      <optionalConform/>
     </event>
     <event side="server" code="0x03" name="ReachableChanged" priority="info" optional="true">
       <description>This event (when supported) SHALL be generated when there is a change in the Reachable attribute.</description>

--- a/src/app/zap-templates/zcl/data-model/chip/binding-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/binding-cluster.xml
@@ -31,9 +31,10 @@ limitations under the License.
     <code>0x001e</code>
     <define>BINDING_CLUSTER</define>
     <description>The Binding Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for supporting the binding table.</description>
-    <attribute side="server" code="0x0000" define="BINDING_LIST" type="array" entryType="TargetStruct" writable="true" optional="false">
-        <description>Binding</description>
-        <access op="write" role="manage"/>
+    <attribute side="server" code="0x0000" define="BINDING_LIST" type="array" entryType="TargetStruct" writable="true">
+      <description>Binding</description>
+      <access op="write" role="manage"/>
+      <mandatoryConform/>
     </attribute>
   </cluster>
 

--- a/src/app/zap-templates/zcl/data-model/chip/boolean-state-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/boolean-state-cluster.xml
@@ -26,11 +26,15 @@ limitations under the License.
     <client tick="false" init="false">true</client>
     <server tick="false" init="false">true</server>
     <globalAttribute side="either" code="0xFFFD" value="1"/>
-    <attribute side="server" code="0x0000" define="STATE_VALUE" type="boolean" writable="false" reportable="true" optional="false">StateValue</attribute>
-
+    <attribute side="server" code="0x0000" define="STATE_VALUE" type="boolean" reportable="true">
+      <description>StateValue</description>
+      <mandatoryConform/>
+    </attribute>
+    
     <event code="0x0000" name="StateChange" priority="info" side="server">
       <description>This event SHALL be generated when the StateValue attribute changes.</description>
       <field id="0" name="StateValue" type="boolean"/>
+      <optionalConform/>
     </event>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/boolean-state-configuration-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/boolean-state-configuration-cluster.xml
@@ -58,34 +58,97 @@ limitations under the License.
       </feature>
     </features>
 
-    <attribute side="server" code="0x0000" define="CURRENT_SENSITIVITY_LEVEL" type="int8u" isNullable="false" writable="true" optional="true">CurrentSensitivityLevel</attribute>
-    <attribute side="server" code="0x0001" define="SUPPORTED_SENSITIVITY_LEVELS" type="int8u" isNullable="false" min="2" max="10" writable="false" optional="true">SupportedSensitivityLevels</attribute>
-    <attribute side="server" code="0x0002" define="DEFAULT_SENSITIVITY_LEVEL" type="int8u" isNullable="false" writable="false" optional="true">DefaultSensitivityLevel</attribute>
-    <attribute side="server" code="0x0003" define="ALARMS_ACTIVE" type="AlarmModeBitmap" isNullable="false" writable="false" optional="true">AlarmsActive</attribute>
-    <attribute side="server" code="0x0004" define="ALARMS_SUPPRESSED" type="AlarmModeBitmap" isNullable="false" writable="false" optional="true">AlarmsSuppressed</attribute>
-    <attribute side="server" code="0x0005" define="ALARMS_ENABLED" type="AlarmModeBitmap" isNullable="false" writable="false" optional="true">AlarmsEnabled</attribute>
-    <attribute side="server" code="0x0006" define="ALARMS_SUPPORTED" type="AlarmModeBitmap" isNullable="false" writable="false" optional="true">AlarmsSupported</attribute>
-    <attribute side="server" code="0x0007" define="SENSOR_FAULT" type="SensorFaultBitmap" isNullable="false" writable="false" default="0" optional="true">SensorFault</attribute>
-
+    <attribute side="server" code="0x0000" define="CURRENT_SENSITIVITY_LEVEL" type="int8u" writable="true" optional="true">
+      <description>CurrentSensitivityLevel</description>
+      <mandatoryConform>
+        <feature name="SENSLVL"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="SUPPORTED_SENSITIVITY_LEVELS" type="int8u" min="2" max="10" optional="true">
+      <description>SupportedSensitivityLevels</description>
+      <mandatoryConform>
+        <feature name="SENSLVL"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="DEFAULT_SENSITIVITY_LEVEL" type="int8u" optional="true">
+      <description>DefaultSensitivityLevel</description>
+      <optionalConform>
+        <feature name="SENSLVL"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="ALARMS_ACTIVE" type="AlarmModeBitmap" optional="true">
+      <description>AlarmsActive</description>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="VIS"/>
+          <feature name="AUD"/>
+        </orTerm>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="ALARMS_SUPPRESSED" type="AlarmModeBitmap" optional="true">
+      <description>AlarmsSuppressed</description>
+      <mandatoryConform>
+        <feature name="SPRS"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="ALARMS_ENABLED" type="AlarmModeBitmap" optional="true">
+      <description>AlarmsEnabled</description>
+      <optionalConform>
+        <orTerm>
+          <feature name="VIS"/>
+          <feature name="AUD"/>
+        </orTerm>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="ALARMS_SUPPORTED" type="AlarmModeBitmap" optional="true">
+      <description>AlarmsSupported</description>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="VIS"/>
+          <feature name="AUD"/>
+        </orTerm>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="SENSOR_FAULT" type="SensorFaultBitmap" default="0" optional="true">
+      <description>SensorFault</description>
+      <optionalConform/>
+    </attribute>
+    
     <command source="client" code="0x00" name="SuppressAlarm" optional="true">
       <description>This command is used to suppress the specified alarm mode.</description>
       <arg name="AlarmsToSuppress" type="AlarmModeBitmap"/>
+      <mandatoryConform>
+        <feature name="SPRS"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x01" name="EnableDisableAlarm" optional="true">
       <description>This command is used to enable or disable the specified alarm mode.</description>
       <arg name="AlarmsToEnableDisable" type="AlarmModeBitmap"/>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="VIS"/>
+          <feature name="AUD"/>
+        </orTerm>
+      </mandatoryConform>
     </command>
 
     <event side="server" code="0x00" priority="info" name="AlarmsStateChanged" optional="true">
       <description>This event SHALL be generated when any bits in the AlarmsActive and/or AlarmsSuppressed attributes change.</description>
       <field id="0" name="AlarmsActive" type="AlarmModeBitmap"/>
       <field id="1" name="AlarmsSuppressed" type="AlarmModeBitmap" optional="true"/>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="VIS"/>
+          <feature name="AUD"/>
+        </orTerm>
+      </mandatoryConform>
     </event>
 
     <event side="server" code="0x01" priority="info" name="SensorFault" optional="true">
       <description>This event SHALL be generated when the device registers or clears a fault.</description>
       <field id="0" name="SensorFault" type="SensorFaultBitmap"/>
+      <optionalConform/>
     </event>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/channel-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/channel-cluster.xml
@@ -41,30 +41,57 @@ limitations under the License.
       </feature>
     </features>
 
-    <attribute side="server" code="0x0000" define="CHANNEL_LIST"            type="array" entryType="ChannelInfoStruct" length="254"                    writable="false" optional="true">ChannelList</attribute>
-    <attribute side="server" code="0x0001" define="CHANNEL_LINEUP"          type="LineupInfoStruct"                    default="0x0" isNullable="true" writable="false" optional="true">Lineup</attribute>
-    <attribute side="server" code="0x0002" define="CHANNEL_CURRENT_CHANNEL" type="ChannelInfoStruct"                   default="0x0" isNullable="true" writable="false" optional="true">CurrentChannel</attribute>
-
+    <attribute side="server" code="0x0000" define="CHANNEL_LIST" type="array" entryType="ChannelInfoStruct" length="254" optional="true">
+      <description>ChannelList</description>
+      <mandatoryConform>
+        <feature name="CL"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="CHANNEL_LINEUP" type="LineupInfoStruct" isNullable="true" optional="true">
+      <description>Lineup</description>
+      <mandatoryConform>
+        <feature name="LI"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="CHANNEL_CURRENT_CHANNEL" type="ChannelInfoStruct" isNullable="true" optional="true">
+      <description>CurrentChannel</description>
+      <optionalConform/>
+    </attribute>
+    
     <command source="client" code="0x00" name="ChangeChannel" response="ChangeChannelResponse" optional="true">
       <description>Change the channel on the media player to the channel case-insensitive exact matching the value passed as an argument. </description>
       <arg name="Match" type="char_string"/>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="CL"/>
+          <feature name="LI"/>
+        </orTerm>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x02" name="ChangeChannelByNumber" optional="false">
       <description>Change the channel on the media plaeyer to the channel with the given Number in the ChannelList attribute.</description>
       <arg name="MajorNumber" type="int16u"/>
       <arg name="MinorNumber" type="int16u"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x03" name="SkipChannel" optional="false">
       <description>This command provides channel up and channel down functionality, but allows channel index jumps of size Count. When the value of the increase or decrease is larger than the number of channels remaining in the given direction, then the behavior SHALL be to return to the beginning (or end) of the channel list and continue. For example, if the current channel is at index 0 and count value of -1 is given, then the current channel should change to the last channel.</description>
       <arg name="Count" type="int16s"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x01" name="ChangeChannelResponse" optional="true">
       <description>Upon receipt, this SHALL display the active status of the input list on screen.</description>
       <arg name="Status" type="StatusEnum"/>
       <arg name="Data"   type="char_string" optional="true"/>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="CL"/>
+          <feature name="LI"/>
+        </orTerm>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x04" name="GetProgramGuide" response="ProgramGuideResponse" optional="true">
@@ -76,12 +103,18 @@ limitations under the License.
       <arg name="RecordingFlag" type="RecordingFlagBitmap" optional="true"/>
       <arg name="ExternalIDList" type="AdditionalInfoStruct" array="true" optional="true"/>
       <arg name="Data" type="octet_string" optional="true"/>
+      <mandatoryConform>
+        <feature name="EG"/>
+      </mandatoryConform>
     </command>
 
     <command source="server" code="0x05" name="ProgramGuideResponse" optional="true" apiMaturity="provisional">
       <description>This command is a response to the GetProgramGuide command.</description>
       <arg name="Paging" type="ChannelPagingStruct"/>
       <arg name="ProgramList" type="ProgramStruct" array="true"/>
+      <mandatoryConform>
+        <feature name="EG"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x06" name="RecordProgram" optional="true">
@@ -90,6 +123,12 @@ limitations under the License.
       <arg name="ShouldRecordSeries" type="boolean"/>
       <arg name="ExternalIDList" type="AdditionalInfoStruct" array="true"/>
       <arg name="Data" type="octet_string"/>
+      <mandatoryConform>
+        <andTerm>
+          <feature name="RP"/>
+          <feature name="EG"/>
+        </andTerm>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x07" name="CancelRecordProgram" optional="true">
@@ -98,6 +137,12 @@ limitations under the License.
       <arg name="ShouldRecordSeries" type="boolean"/>
       <arg name="ExternalIDList" type="AdditionalInfoStruct" array="true"/>
       <arg name="Data" type="octet_string"/>
+      <mandatoryConform>
+        <andTerm>
+          <feature name="RP"/>
+          <feature name="EG"/>
+        </andTerm>
+      </mandatoryConform>
     </command>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/color-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/color-control-cluster.xml
@@ -126,136 +126,402 @@ limitations under the License.
         <optionalConform/>
       </feature>
     </features>
-
-    <attribute side="server" code="0x0000" define="COLOR_CONTROL_CURRENT_HUE" type="int8u" min="0x00" max="0xFE" writable="false" reportable="true" default="0x00" optional="true">CurrentHue</attribute>
+    
+    <attribute side="server" code="0x0000" define="COLOR_CONTROL_CURRENT_HUE" type="int8u" max="0xFE" reportable="true" default="0x00" optional="true">
+      <description>CurrentHue</description>
+      <mandatoryConform>
+        <feature name="HS"/>
+      </mandatoryConform>
+    </attribute>
     <!-- CURRENT_HUE -->
-    <attribute side="server" code="0x0001" define="COLOR_CONTROL_CURRENT_SATURATION" type="int8u" min="0x00" max="0xFE" writable="false" reportable="true" default="0x00" optional="true">CurrentSaturation</attribute>
+    <attribute side="server" code="0x0001" define="COLOR_CONTROL_CURRENT_SATURATION" type="int8u" max="0xFE" reportable="true" default="0x00" optional="true">
+      <description>CurrentSaturation</description>
+      <mandatoryConform>
+        <feature name="HS"/>
+      </mandatoryConform>
+    </attribute>
     <!-- CURRENT_SATURATION -->
-    <attribute side="server" code="0x0002" define="COLOR_CONTROL_REMAINING_TIME" type="int16u" min="0x0000" max="0xFFFE" writable="false" default="0x0000" optional="true">RemainingTime</attribute>
+    <attribute side="server" code="0x0002" define="COLOR_CONTROL_REMAINING_TIME" type="int16u" max="0xFFFE" default="0x0000" optional="true">
+      <description>RemainingTime</description>
+      <optionalConform/>
+    </attribute>
     <!-- REMAINING_TIME -->
-    <attribute side="server" code="0x0003" define="COLOR_CONTROL_CURRENT_X" type="int16u" min="0x0000" max="0xFEFF" writable="false" reportable="true" default="0x616B" optional="true">CurrentX</attribute>
+    <attribute side="server" code="0x0003" define="COLOR_CONTROL_CURRENT_X" type="int16u" max="0xFEFF" default="0x616B" reportable="true" optional="true">
+      <description>CurrentX</description>
+      <mandatoryConform>
+        <feature name="XY"/>
+      </mandatoryConform>
+    </attribute>
     <!-- CURRENT_X -->
-    <attribute side="server" code="0x0004" define="COLOR_CONTROL_CURRENT_Y" type="int16u" min="0x0000" max="0xFEFF" writable="false" reportable="true" default="0x607D" optional="true">CurrentY</attribute>
+    <attribute side="server" code="0x0004" define="COLOR_CONTROL_CURRENT_Y" type="int16u" max="0xFEFF" default="0x607D" reportable="true" optional="true">
+      <description>CurrentY</description>
+      <mandatoryConform>
+        <feature name="XY"/>
+      </mandatoryConform>
+    </attribute>
     <!-- CURRENT_Y -->
-    <attribute side="server" code="0x0005" define="COLOR_CONTROL_DRIFT_COMPENSATION" type="DriftCompensationEnum" writable="false" optional="true">DriftCompensation</attribute>
+    <attribute side="server" code="0x0005" define="COLOR_CONTROL_DRIFT_COMPENSATION" type="DriftCompensationEnum" optional="true">
+      <description>DriftCompensation</description>
+      <optionalConform/>
+    </attribute>
     <!-- DRIFT_COMPENSATION -->
-    <attribute side="server" code="0x0006" define="COLOR_CONTROL_COMPENSATION_TEXT" type="char_string" length="254" writable="false" optional="true">CompensationText</attribute>
+    <attribute side="server" code="0x0006" define="COLOR_CONTROL_COMPENSATION_TEXT" type="char_string" length="254" optional="true">
+      <description>CompensationText</description>
+      <optionalConform/>
+    </attribute>
     <!-- COMPENSATION_TEXT -->
-    <attribute side="server" code="0x0007" define="COLOR_CONTROL_COLOR_TEMPERATURE" type="int16u" min="0x0001" max="0xFEFF" writable="false" reportable="true" default="0x00FA" optional="true">ColorTemperatureMireds</attribute>
+    <attribute side="server" code="0x0007" define="COLOR_CONTROL_COLOR_TEMPERATURE" type="int16u" min="0x0001" max="0xFEFF" reportable="true" default="0x00FA" optional="true">
+      <description>ColorTemperatureMireds</description>
+      <mandatoryConform>
+        <feature name="CT"/>
+      </mandatoryConform>
+    </attribute>
     <!-- COLOR_TEMPERATURE -->
-    <attribute side="server" code="0x0008" define="COLOR_CONTROL_COLOR_MODE" type="ColorModeEnum" writable="false" default="0x01">ColorMode</attribute>
+    <attribute side="server" code="0x0008" define="COLOR_CONTROL_COLOR_MODE" type="ColorModeEnum" default="0x01">
+      <description>ColorMode</description>
+      <mandatoryConform/>
+    </attribute>
     <!-- COLOR_MODE -->
-    <attribute side="server" code="0x000F" define="COLOR_CONTROL_OPTIONS" type="OptionsBitmap" writable="true" default="0x00">Options</attribute>
+    <attribute side="server" code="0x000F" define="COLOR_CONTROL_OPTIONS" type="OptionsBitmap" writable="true" default="0x00">
+      <description>Options</description>
+      <mandatoryConform/>
+    </attribute>
     <!-- COLOR_CONTROL_OPTIONS -->
-    <attribute side="server" code="0x0010" define="COLOR_CONTROL_NUMBER_OF_PRIMARIES" type="int8u" min="0x00" max="0x06" isNullable="true" writable="false">NumberOfPrimaries</attribute>
+    <attribute side="server" code="0x0010" define="COLOR_CONTROL_NUMBER_OF_PRIMARIES" type="int8u" max="0x06" isNullable="true">
+      <description>NumberOfPrimaries</description>
+      <mandatoryConform/>
+    </attribute>
     <!-- NUMBER_OF_PRIMARIES -->
-    <attribute side="server" code="0x0011" define="COLOR_CONTROL_PRIMARY_1_X" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">Primary1X</attribute>
+    <attribute side="server" code="0x0011" define="COLOR_CONTROL_PRIMARY_1_X" type="int16u" max="0xFEFF" optional="true">
+      <description>Primary1X</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="0"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_1_X -->
-    <attribute side="server" code="0x0012" define="COLOR_CONTROL_PRIMARY_1_Y" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">Primary1Y</attribute>
+    <attribute side="server" code="0x0012" define="COLOR_CONTROL_PRIMARY_1_Y" type="int16u" max="0xFEFF" optional="true">
+      <description>Primary1Y</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="0"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_1_Y -->
-    <attribute side="server" code="0x0013" define="COLOR_CONTROL_PRIMARY_1_INTENSITY" type="int8u" min="0x00" max="0xFF" isNullable="true" writable="false" optional="true">Primary1Intensity</attribute>
+    <attribute side="server" code="0x0013" define="COLOR_CONTROL_PRIMARY_1_INTENSITY" type="int8u" isNullable="true" optional="true">
+      <description>Primary1Intensity</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="0"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_1_INTENSITY -->
-    <attribute side="server" code="0x0015" define="COLOR_CONTROL_PRIMARY_2_X" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">Primary2X</attribute>
+    <attribute side="server" code="0x0015" define="COLOR_CONTROL_PRIMARY_2_X" type="int16u" max="0xFEFF" optional="true">
+      <description>Primary2X</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="1"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_2_X -->
-    <attribute side="server" code="0x0016" define="COLOR_CONTROL_PRIMARY_2_Y" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">Primary2Y</attribute>
+    <attribute side="server" code="0x0016" define="COLOR_CONTROL_PRIMARY_2_Y" type="int16u" max="0xFEFF" optional="true">
+      <description>Primary2Y</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="1"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_2_Y -->
-    <attribute side="server" code="0x0017" define="COLOR_CONTROL_PRIMARY_2_INTENSITY" type="int8u" min="0x00" max="0xFF" isNullable="true" writable="false" optional="true">Primary2Intensity</attribute>
+    <attribute side="server" code="0x0017" define="COLOR_CONTROL_PRIMARY_2_INTENSITY" type="int8u" isNullable="true" optional="true">
+      <description>Primary2Intensity</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="1"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_2_INTENSITY -->
-    <attribute side="server" code="0x0019" define="COLOR_CONTROL_PRIMARY_3_X" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">Primary3X</attribute>
+    <attribute side="server" code="0x0019" define="COLOR_CONTROL_PRIMARY_3_X" type="int16u" max="0xFEFF" optional="true">
+      <description>Primary3X</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="2"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_3_X -->
-    <attribute side="server" code="0x001A" define="COLOR_CONTROL_PRIMARY_3_Y" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">Primary3Y</attribute>
+    <attribute side="server" code="0x001A" define="COLOR_CONTROL_PRIMARY_3_Y" type="int16u" max="0xFEFF" optional="true">
+      <description>Primary3Y</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="2"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_3_Y -->
-    <attribute side="server" code="0x001B" define="COLOR_CONTROL_PRIMARY_3_INTENSITY" type="int8u" min="0x00" max="0xFF" isNullable="true" writable="false" optional="true">Primary3Intensity</attribute>
+    <attribute side="server" code="0x001B" define="COLOR_CONTROL_PRIMARY_3_INTENSITY" type="int8u" isNullable="true" optional="true">
+      <description>Primary3Intensity</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="2"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_3_INTENSITY -->
-    <attribute side="server" code="0x0020" define="COLOR_CONTROL_PRIMARY_4_X" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">Primary4X</attribute>
+    <attribute side="server" code="0x0020" define="COLOR_CONTROL_PRIMARY_4_X" type="int16u" max="0xFEFF" optional="true">
+      <description>Primary4X</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="3"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_4_X -->
-    <attribute side="server" code="0x0021" define="COLOR_CONTROL_PRIMARY_4_Y" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">Primary4Y</attribute>
+    <attribute side="server" code="0x0021" define="COLOR_CONTROL_PRIMARY_4_Y" type="int16u" max="0xFEFF" optional="true">
+      <description>Primary4Y</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="3"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_4_Y -->
-    <attribute side="server" code="0x0022" define="COLOR_CONTROL_PRIMARY_4_INTENSITY" type="int8u" min="0x00" max="0xFF" isNullable="true" writable="false" optional="true">Primary4Intensity</attribute>
+    <attribute side="server" code="0x0022" define="COLOR_CONTROL_PRIMARY_4_INTENSITY" type="int8u" isNullable="true" optional="true">
+      <description>Primary4Intensity</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="3"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_4_INTENSITY -->
-    <attribute side="server" code="0x0024" define="COLOR_CONTROL_PRIMARY_5_X" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">Primary5X</attribute>
+    <attribute side="server" code="0x0024" define="COLOR_CONTROL_PRIMARY_5_X" type="int16u" max="0xFEFF" optional="true">
+      <description>Primary5X</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="4"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_5_X -->
-    <attribute side="server" code="0x0025" define="COLOR_CONTROL_PRIMARY_5_Y" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">Primary5Y</attribute>
+    <attribute side="server" code="0x0025" define="COLOR_CONTROL_PRIMARY_5_Y" type="int16u" max="0xFEFF" optional="true">
+      <description>Primary5Y</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="4"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_5_Y -->
-    <attribute side="server" code="0x0026" define="COLOR_CONTROL_PRIMARY_5_INTENSITY" type="int8u" min="0x00" max="0xFF" isNullable="true" writable="false" optional="true">Primary5Intensity</attribute>
+    <attribute side="server" code="0x0026" define="COLOR_CONTROL_PRIMARY_5_INTENSITY" type="int8u" isNullable="true" optional="true">
+      <description>Primary5Intensity</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="4"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_5_INTENSITY -->
-    <attribute side="server" code="0x0028" define="COLOR_CONTROL_PRIMARY_6_X" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">Primary6X</attribute>
+    <attribute side="server" code="0x0028" define="COLOR_CONTROL_PRIMARY_6_X" type="int16u" max="0xFEFF" optional="true">
+      <description>Primary6X</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="5"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_6_X -->
-    <attribute side="server" code="0x0029" define="COLOR_CONTROL_PRIMARY_6_Y" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">Primary6Y</attribute>
+    <attribute side="server" code="0x0029" define="COLOR_CONTROL_PRIMARY_6_Y" type="int16u" max="0xFEFF" optional="true">
+      <description>Primary6Y</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="5"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_6_Y -->
-    <attribute side="server" code="0x002A" define="COLOR_CONTROL_PRIMARY_6_INTENSITY" type="int8u" min="0x00" max="0xFF" isNullable="true" writable="false" optional="true">Primary6Intensity</attribute>
+    <attribute side="server" code="0x002A" define="COLOR_CONTROL_PRIMARY_6_INTENSITY" type="int8u" isNullable="true" optional="true">
+      <description>Primary6Intensity</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="5"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_6_INTENSITY -->
     <attribute side="server" code="0x0030" define="COLOR_CONTROL_WHITE_POINT_X" type="int16u" min="0x0000" max="0xFEFF" writable="true" optional="true">
       <description>WhitePointX</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <optionalConform/>
     </attribute>
     <!-- WHITE_POINT_X -->
     <attribute side="server" code="0x0031" define="COLOR_CONTROL_WHITE_POINT_Y" type="int16u" min="0x0000" max="0xFEFF" writable="true" optional="true">
       <description>WhitePointY</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <optionalConform/>
     </attribute>
     <!-- WHITE_POINT_Y -->
     <attribute side="server" code="0x0032" define="COLOR_CONTROL_COLOR_POINT_R_X" type="int16u" min="0x0000" max="0xFEFF" writable="true" optional="true">
       <description>ColorPointRX</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <optionalConform/>
     </attribute>
     <!-- COLOR_POINT_R_X -->
     <attribute side="server" code="0x0033" define="COLOR_CONTROL_COLOR_POINT_R_Y" type="int16u" min="0x0000" max="0xFEFF" writable="true" optional="true">
       <description>ColorPointRY</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <optionalConform/>
     </attribute>
     <!-- COLOR_POINT_R_Y -->
     <attribute side="server" code="0x0034" define="COLOR_CONTROL_COLOR_POINT_R_INTENSITY" type="int8u" isNullable="true" writable="true" optional="true">
       <description>ColorPointRIntensity</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <optionalConform/>
     </attribute>
     <!-- COLOR_POINT_R_INTENSITY -->
     <attribute side="server" code="0x0036" define="COLOR_CONTROL_COLOR_POINT_G_X" type="int16u" min="0x0000" max="0xFEFF" writable="true" optional="true">
       <description>ColorPointGX</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <optionalConform/>
     </attribute>
     <!-- COLOR_POINT_G_X -->
     <attribute side="server" code="0x0037" define="COLOR_CONTROL_COLOR_POINT_G_Y" type="int16u" min="0x0000" max="0xFEFF" writable="true" optional="true">
       <description>ColorPointGY</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <optionalConform/>
     </attribute>
     <!-- COLOR_POINT_G_Y -->
     <attribute side="server" code="0x0038" define="COLOR_CONTROL_COLOR_POINT_G_INTENSITY" type="int8u" isNullable="true" writable="true" optional="true">
       <description>ColorPointGIntensity</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <optionalConform/>
     </attribute>
     <!-- COLOR_POINT_G_INTENSITY -->
     <attribute side="server" code="0x003A" define="COLOR_CONTROL_COLOR_POINT_B_X" type="int16u" min="0x0000" max="0xFEFF" writable="true" optional="true">
       <description>ColorPointBX</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <optionalConform/>
     </attribute>
     <!-- COLOR_POINT_B_X -->
     <attribute side="server" code="0x003B" define="COLOR_CONTROL_COLOR_POINT_B_Y" type="int16u" min="0x0000" max="0xFEFF" writable="true" optional="true">
       <description>ColorPointBY</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <optionalConform/>
     </attribute>
     <!-- COLOR_POINT_B_Y -->
     <attribute side="server" code="0x003C" define="COLOR_CONTROL_COLOR_POINT_B_INTENSITY" type="int8u" isNullable="true" writable="true" optional="true">
       <description>ColorPointBIntensity</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <optionalConform/>
     </attribute>
     <!-- COLOR_POINT_B_INTENSITY -->
-    <attribute side="server" code="0x400D" define="COLOR_CONTROL_TEMPERATURE_LEVEL_MIN_MIREDS" type="int16u" min="0x0000" max="0xFFFF" writable="false" optional="true">CoupleColorTempToLevelMinMireds</attribute>
-    <attribute side="server" code="0x4010" define="START_UP_COLOR_TEMPERATURE_MIREDS" type="int16u" min="0x0000" max="0xFEFF" writable="true" isNullable="true" optional="true">
+    <attribute side="server" code="0x400D" define="COLOR_CONTROL_TEMPERATURE_LEVEL_MIN_MIREDS" type="int16u" optional="true">
+      <description>CoupleColorTempToLevelMinMireds</description>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="CT"/>
+          <attribute name="ColorTemperatureMireds"/>
+        </orTerm>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x4010" define="START_UP_COLOR_TEMPERATURE_MIREDS" type="int16u" max="0xFEFF" writable="true" isNullable="true" optional="true">
       <description>StartUpColorTemperatureMireds</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="CT"/>
+          <attribute name="ColorTemperatureMireds"/>
+        </orTerm>
+      </mandatoryConform>
     </attribute>
 
     <command source="client" code="0x00" name="MoveToHue" optional="true" cli="zcl color-control movetohue">
@@ -267,6 +533,9 @@ limitations under the License.
       <arg name="TransitionTime" type="int16u"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform>
+        <feature name="HS"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x01" name="MoveHue" optional="true" cli="zcl color-control movehue">
@@ -277,6 +546,9 @@ limitations under the License.
       <arg name="Rate" type="int8u"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform>
+        <feature name="HS"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x02" name="StepHue" optional="true" cli="zcl color-control stephue">
@@ -288,6 +560,9 @@ limitations under the License.
       <arg name="TransitionTime" type="int8u"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform>
+        <feature name="HS"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x03" name="MoveToSaturation" optional="true" cli="zcl color-control movetosat">
@@ -298,6 +573,9 @@ limitations under the License.
       <arg name="TransitionTime" type="int16u"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform>
+        <feature name="HS"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x04" name="MoveSaturation" optional="true" cli="zcl color-control movesat">
@@ -308,6 +586,9 @@ limitations under the License.
       <arg name="Rate" type="int8u"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform>
+        <feature name="HS"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x05" name="StepSaturation" optional="true" cli="zcl color-control stepsat">
@@ -319,6 +600,9 @@ limitations under the License.
       <arg name="TransitionTime" type="int8u"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform>
+        <feature name="HS"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x06" name="MoveToHueAndSaturation" optional="true" cli="zcl color-control movetohueandsat">
@@ -330,6 +614,9 @@ limitations under the License.
       <arg name="TransitionTime" type="int16u"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform>
+        <feature name="HS"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x07" name="MoveToColor" optional="true" cli="zcl color-control movetocolor">
@@ -341,6 +628,9 @@ limitations under the License.
       <arg name="TransitionTime" type="int16u"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform>
+        <feature name="XY"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x08" name="MoveColor" optional="true" cli="zcl color-control movecolor">
@@ -351,6 +641,9 @@ limitations under the License.
       <arg name="RateY" type="int16s"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform>
+        <feature name="XY"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x09" name="StepColor" optional="true" cli="zcl color-control stepcolor">
@@ -362,6 +655,9 @@ limitations under the License.
       <arg name="TransitionTime" type="int16u"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform>
+        <feature name="XY"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x0A" name="MoveToColorTemperature" optional="true" cli="zcl color-control movetocolortemp">
@@ -372,6 +668,9 @@ limitations under the License.
       <arg name="TransitionTime" type="int16u"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform>
+        <feature name="CT"/>
+      </mandatoryConform>
     </command>
   </cluster>
 

--- a/src/app/zap-templates/zcl/data-model/chip/color-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/color-control-cluster.xml
@@ -126,7 +126,7 @@ limitations under the License.
         <optionalConform/>
       </feature>
     </features>
-    
+
     <attribute side="server" code="0x0000" define="COLOR_CONTROL_CURRENT_HUE" type="int8u" max="0xFE" reportable="true" default="0x00" optional="true">
       <description>CurrentHue</description>
       <mandatoryConform>
@@ -675,16 +675,62 @@ limitations under the License.
   </cluster>
 
   <clusterExtension code="0x0300">
-    <attribute side="server" code="0x4000" define="COLOR_CONTROL_ENHANCED_CURRENT_HUE" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">EnhancedCurrentHue</attribute>
-    <attribute side="server" code="0x4001" define="COLOR_CONTROL_ENHANCED_COLOR_MODE" type="EnhancedColorModeEnum" writable="false" default="0x01">EnhancedColorMode</attribute>
-    <attribute side="server" code="0x4002" define="COLOR_CONTROL_COLOR_LOOP_ACTIVE" type="int8u" min="0x00" max="0x01" writable="false" default="0x00" optional="true">ColorLoopActive</attribute>
-    <attribute side="server" code="0x4003" define="COLOR_CONTROL_COLOR_LOOP_DIRECTION" type="int8u" min="0x00" max="0x01" writable="false" default="0x00" optional="true">ColorLoopDirection</attribute>
-    <attribute side="server" code="0x4004" define="COLOR_CONTROL_COLOR_LOOP_TIME" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x0019" optional="true">ColorLoopTime</attribute>
-    <attribute side="server" code="0x4005" define="COLOR_CONTROL_COLOR_LOOP_START_ENHANCED_HUE" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x2300" optional="true">ColorLoopStartEnhancedHue</attribute>
-    <attribute side="server" code="0x4006" define="COLOR_CONTROL_COLOR_LOOP_STORED_ENHANCED_HUE" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">ColorLoopStoredEnhancedHue</attribute>
-    <attribute side="server" code="0x400A" define="COLOR_CONTROL_COLOR_CAPABILITIES" type="ColorCapabilitiesBitmap" min="0x0000" max="0x001F" writable="false" default="0x0000">ColorCapabilities</attribute>
-    <attribute side="server" code="0x400B" define="COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MIN" type="int16u" min="0x0001" max="0xFEFF" writable="false" default="0x0000" optional="true">ColorTempPhysicalMinMireds</attribute>
-    <attribute side="server" code="0x400C" define="COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MAX" type="int16u" min="0x0000" max="0xFEFF" writable="false" default="0xFEFF" optional="true">ColorTempPhysicalMaxMireds</attribute>
+    <attribute side="server" code="0x4000" define="COLOR_CONTROL_ENHANCED_CURRENT_HUE" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">
+      <description>EnhancedCurrentHue</description>
+      <mandatoryConform>
+        <feature name="EHUE"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x4001" define="COLOR_CONTROL_ENHANCED_COLOR_MODE" type="EnhancedColorModeEnum" writable="false" default="0x01">
+      <description>EnhancedColorMode</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x4002" define="COLOR_CONTROL_COLOR_LOOP_ACTIVE" type="int8u" min="0x00" max="0x01" writable="false" default="0x00" optional="true">
+      <description>ColorLoopActive</description>
+      <mandatoryConform>
+        <feature name="CL"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x4003" define="COLOR_CONTROL_COLOR_LOOP_DIRECTION" type="int8u" min="0x00" max="0x01" writable="false" default="0x00" optional="true">
+      <description>ColorLoopDirection</description>
+      <mandatoryConform>
+        <feature name="CL"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x4004" define="COLOR_CONTROL_COLOR_LOOP_TIME" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x0019" optional="true">
+      <description>ColorLoopTime</description>
+      <mandatoryConform>
+        <feature name="CL"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x4005" define="COLOR_CONTROL_COLOR_LOOP_START_ENHANCED_HUE" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x2300" optional="true">
+      <description>ColorLoopStartEnhancedHue</description>
+      <mandatoryConform>
+        <feature name="CL"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x4006" define="COLOR_CONTROL_COLOR_LOOP_STORED_ENHANCED_HUE" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">
+      <description>ColorLoopStoredEnhancedHue</description>
+      <mandatoryConform>
+        <feature name="CL"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x400A" define="COLOR_CONTROL_COLOR_CAPABILITIES" type="ColorCapabilitiesBitmap" min="0x0000" max="0x001F" writable="false" default="0x0000">
+      <description>ColorCapabilities</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x400B" define="COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MIN" type="int16u" min="0x0001" max="0xFEFF" writable="false" default="0x0000" optional="true">
+      <description>ColorTempPhysicalMinMireds</description>
+      <mandatoryConform>
+        <feature name="CT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x400C" define="COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MAX" type="int16u" min="0x0000" max="0xFEFF" writable="false" default="0xFEFF" optional="true">
+      <description>ColorTempPhysicalMaxMireds</description>
+      <mandatoryConform>
+        <feature name="CT"/>
+      </mandatoryConform>
+    </attribute>
 
     <command source="client" code="0x40" name="EnhancedMoveToHue" optional="true" noDefaultImplementation="true" cli="zcl color-control emovetohue">
       <description>
@@ -695,6 +741,9 @@ limitations under the License.
       <arg name="TransitionTime" type="int16u"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform>
+        <feature name="EHUE"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x41" name="EnhancedMoveHue" optional="true" noDefaultImplementation="true" cli="zcl color-control emovehue">
@@ -705,6 +754,9 @@ limitations under the License.
       <arg name="Rate" type="int16u"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform>
+        <feature name="EHUE"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x42" name="EnhancedStepHue" optional="true" noDefaultImplementation="true" cli="zcl color-control estephue">
@@ -716,6 +768,9 @@ limitations under the License.
       <arg name="TransitionTime" type="int16u"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform>
+        <feature name="EHUE"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x43" name="EnhancedMoveToHueAndSaturation" optional="true" noDefaultImplementation="true" cli="zcl color-control emovetohueandsat">
@@ -727,6 +782,9 @@ limitations under the License.
       <arg name="TransitionTime" type="int16u"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform>
+        <feature name="EHUE"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x44" name="ColorLoopSet" optional="true" noDefaultImplementation="true" cli="zcl color-control loop">
@@ -740,6 +798,9 @@ limitations under the License.
       <arg name="StartHue" type="int16u"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform>
+        <feature name="CL"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x47" name="StopMoveStep" optional="true" noDefaultImplementation="true" cli="zcl color-control stopmovestep">
@@ -748,6 +809,13 @@ limitations under the License.
       </description>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="HS"/>
+          <feature name="XY"/>
+          <feature name="CT"/>
+        </orTerm>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x4B" name="MoveColorTemperature" optional="true" noDefaultImplementation="true" cli="zcl color-control movecolortemp">
@@ -760,6 +828,9 @@ limitations under the License.
       <arg name="ColorTemperatureMaximumMireds" type="int16u"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform>
+        <feature name="CT"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x4C" name="StepColorTemperature" optional="true" noDefaultImplementation="true" cli="zcl color-control stepcolortemp">
@@ -773,6 +844,9 @@ limitations under the License.
       <arg name="ColorTemperatureMaximumMireds" type="int16u"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform>
+        <feature name="CT"/>
+      </mandatoryConform>
     </command>
   </clusterExtension>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/commissioner-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/commissioner-control-cluster.xml
@@ -35,6 +35,7 @@ limitations under the License.
     <attribute side="server" code="0x0000" define="SUPPORTED_DEVICE_CATEGORIES" type="SupportedDeviceCategoryBitmap" default="0" min="0x00000000" max="0x00000001">
       <description>SupportedDeviceCategories</description>
       <access op="read" privilege="manage"/>
+      <mandatoryConform/>
     </attribute>
 
     <command source="client" code="0x00" name="RequestCommissioningApproval" optional="false">
@@ -44,6 +45,7 @@ limitations under the License.
       <arg id="2" name="ProductID" type="int16u"/>
       <arg id="3" name="Label" type="char_string" optional="true" length="64"/>
       <access op="invoke" privilege="manage"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x01" name="CommissionNode" response="ReverseOpenCommissioningWindow" optional="false">
@@ -51,6 +53,7 @@ limitations under the License.
       <arg id="0" name="RequestID" type="int64u"/>
       <arg id="1" name="ResponseTimeoutSeconds" type="int16u" min="30" max="120" default="30"/>
       <access op="invoke" privilege="manage"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x02" name="ReverseOpenCommissioningWindow" optional="false" disableDefaultResponse="true">
@@ -60,6 +63,7 @@ limitations under the License.
       <arg id="2" name="Discriminator" type="int16u" min="0" max="4095"/>
       <arg id="3" name="Iterations" type="int32u" min="1000" max="100000"/>
       <arg id="4" name="Salt" type="octet_string" length="32" minLength="16"/>
+      <mandatoryConform/>
     </command>
 
     <event code="0x00" name="CommissioningRequestResult" priority="info" side="server" isFabricSensitive="true">
@@ -68,6 +72,7 @@ limitations under the License.
       <field id="1" name="ClientNodeID" type="node_id"/>
       <field id="2" name="StatusCode" type="status"/>
       <access op="read" privilege="manage"/>
+      <mandatoryConform/>
     </event>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/concentration-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/concentration-measurement-cluster.xml
@@ -58,17 +58,70 @@ limitations under the License.
       </feature>
     </features>
 
-    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
-    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
-    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">PeakMeasuredValue</attribute>
-    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">PeakMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">AverageMeasuredValue</attribute>
-    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">AverageMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">Uncertainty</attribute>
-    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">MeasurementUnit</attribute>
-    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">MeasurementMedium</attribute>
-    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">LevelValue</attribute>
+    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>PeakMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" max="604800" default="1" optional="true">
+      <description>PeakMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>AverageMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" max="604800" default="1" optional="true">
+      <description>AverageMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" optional="true">
+      <description>Uncertainty</description>
+      <optionalConform>
+        <feature name="MEA"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" optional="true">
+      <description>MeasurementUnit</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" optional="true">
+      <description>MeasurementMedium</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" default="0" optional="true">
+      <description>LevelValue</description>
+      <mandatoryConform>
+        <feature name="LEV"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 
   <cluster>
@@ -113,17 +166,70 @@ limitations under the License.
      </features>
 
     <!-- Attributes -->
-    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
-    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
-    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">PeakMeasuredValue</attribute>
-    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">PeakMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">AverageMeasuredValue</attribute>
-    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">AverageMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">Uncertainty</attribute>
-    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">MeasurementUnit</attribute>
-    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">MeasurementMedium</attribute>
-    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">LevelValue</attribute>
+    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>PeakMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" max="604800" default="1" optional="true">
+      <description>PeakMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>AverageMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" max="604800" default="1" optional="true">
+      <description>AverageMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" optional="true">
+      <description>Uncertainty</description>
+      <optionalConform>
+        <feature name="MEA"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" optional="true">
+      <description>MeasurementUnit</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" optional="true">
+      <description>MeasurementMedium</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" default="0" optional="true">
+      <description>LevelValue</description>
+      <mandatoryConform>
+        <feature name="LEV"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 
   <cluster>
@@ -139,45 +245,98 @@ limitations under the License.
     <globalAttribute side="either" code="0xFFFD" value="3"/>
 
     <features>
-       <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
-         <optionalConform choice="a" more="true"/>
-       </feature>
-       <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
-         <optionalConform choice="a" more="true"/>
-       </feature>
-       <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
-         <optionalConform>
-           <feature name="LEV"/>
-         </optionalConform>
-       </feature>
-       <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
-         <optionalConform>
-           <feature name="LEV"/>
-         </optionalConform>
-       </feature>
-       <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
-         <optionalConform>
-           <feature name="MEA"/>
-         </optionalConform>
-       </feature>
-       <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
-         <optionalConform>
-           <feature name="MEA"/>
-         </optionalConform>
-       </feature>
-     </features>
+      <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
+        <optionalConform>
+          <feature name="LEV"/>
+        </optionalConform>
+      </feature>
+      <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
+        <optionalConform>
+          <feature name="LEV"/>
+        </optionalConform>
+      </feature>
+      <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
+        <optionalConform>
+          <feature name="MEA"/>
+        </optionalConform>
+      </feature>
+      <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
+        <optionalConform>
+          <feature name="MEA"/>
+        </optionalConform>
+      </feature>
+    </features>
 
-    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
-    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
-    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">PeakMeasuredValue</attribute>
-    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">PeakMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">AverageMeasuredValue</attribute>
-    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">AverageMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">Uncertainty</attribute>
-    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">MeasurementUnit</attribute>
-    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">MeasurementMedium</attribute>
-    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">LevelValue</attribute>
+    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>PeakMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" max="604800" default="1" optional="true">
+      <description>PeakMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>AverageMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" max="604800" default="1" optional="true">
+      <description>AverageMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" optional="true">
+      <description>Uncertainty</description>
+      <optionalConform>
+        <feature name="MEA"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" optional="true">
+      <description>MeasurementUnit</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" optional="true">
+      <description>MeasurementMedium</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" default="0" optional="true">
+      <description>LevelValue</description>
+      <mandatoryConform>
+        <feature name="LEV"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 
   <cluster>
@@ -193,45 +352,98 @@ limitations under the License.
     <globalAttribute side="either" code="0xFFFD" value="3"/>
 
     <features>
-       <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
-         <optionalConform choice="a" more="true"/>
-       </feature>
-       <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
-         <optionalConform choice="a" more="true"/>
-       </feature>
-       <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
-         <optionalConform>
-           <feature name="LEV"/>
-         </optionalConform>
-       </feature>
-       <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
-         <optionalConform>
-           <feature name="LEV"/>
-         </optionalConform>
-       </feature>
-       <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
-         <optionalConform>
-           <feature name="MEA"/>
-         </optionalConform>
-       </feature>
-       <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
-         <optionalConform>
-           <feature name="MEA"/>
-         </optionalConform>
-       </feature>
-     </features>
+      <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
+        <optionalConform>
+          <feature name="LEV"/>
+        </optionalConform>
+      </feature>
+      <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
+        <optionalConform>
+          <feature name="LEV"/>
+        </optionalConform>
+      </feature>
+      <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
+        <optionalConform>
+          <feature name="MEA"/>
+        </optionalConform>
+      </feature>
+      <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
+        <optionalConform>
+          <feature name="MEA"/>
+        </optionalConform>
+      </feature>
+    </features>
 
-    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
-    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
-    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">PeakMeasuredValue</attribute>
-    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">PeakMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">AverageMeasuredValue</attribute>
-    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">AverageMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">Uncertainty</attribute>
-    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">MeasurementUnit</attribute>
-    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">MeasurementMedium</attribute>
-    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">LevelValue</attribute>
+    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>PeakMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" max="604800" default="1" optional="true">
+      <description>PeakMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>AverageMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" max="604800" default="1" optional="true">
+      <description>AverageMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" optional="true">
+      <description>Uncertainty</description>
+      <optionalConform>
+        <feature name="MEA"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" optional="true">
+      <description>MeasurementUnit</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" optional="true">
+      <description>MeasurementMedium</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" default="0" optional="true">
+      <description>LevelValue</description>
+      <mandatoryConform>
+        <feature name="LEV"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 
   <cluster>
@@ -247,45 +459,98 @@ limitations under the License.
     <globalAttribute side="either" code="0xFFFD" value="3"/>
 
     <features>
-       <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
-         <optionalConform choice="a" more="true"/>
-       </feature>
-       <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
-         <optionalConform choice="a" more="true"/>
-       </feature>
-       <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
-         <optionalConform>
-           <feature name="LEV"/>
-         </optionalConform>
-       </feature>
-       <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
-         <optionalConform>
-           <feature name="LEV"/>
-         </optionalConform>
-       </feature>
-       <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
-         <optionalConform>
-           <feature name="MEA"/>
-         </optionalConform>
-       </feature>
-       <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
-         <optionalConform>
-           <feature name="MEA"/>
-         </optionalConform>
-       </feature>
-     </features>
+      <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
+        <optionalConform>
+          <feature name="LEV"/>
+        </optionalConform>
+      </feature>
+      <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
+        <optionalConform>
+          <feature name="LEV"/>
+        </optionalConform>
+      </feature>
+      <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
+        <optionalConform>
+          <feature name="MEA"/>
+        </optionalConform>
+      </feature>
+      <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
+        <optionalConform>
+          <feature name="MEA"/>
+        </optionalConform>
+      </feature>
+    </features>
 
-    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
-    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
-    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">PeakMeasuredValue</attribute>
-    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">PeakMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">AverageMeasuredValue</attribute>
-    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">AverageMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">Uncertainty</attribute>
-    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">MeasurementUnit</attribute>
-    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">MeasurementMedium</attribute>
-    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">LevelValue</attribute>
+    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>PeakMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" max="604800" default="1" optional="true">
+      <description>PeakMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>AverageMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" max="604800" default="1" optional="true">
+      <description>AverageMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" optional="true">
+      <description>Uncertainty</description>
+      <optionalConform>
+        <feature name="MEA"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" optional="true">
+      <description>MeasurementUnit</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" optional="true">
+      <description>MeasurementMedium</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" default="0" optional="true">
+      <description>LevelValue</description>
+      <mandatoryConform>
+        <feature name="LEV"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 
   <cluster>
@@ -301,45 +566,98 @@ limitations under the License.
     <globalAttribute side="either" code="0xFFFD" value="3"/>
 
     <features>
-       <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
-         <optionalConform choice="a" more="true"/>
-       </feature>
-       <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
-         <optionalConform choice="a" more="true"/>
-       </feature>
-       <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
-         <optionalConform>
-           <feature name="LEV"/>
-         </optionalConform>
-       </feature>
-       <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
-         <optionalConform>
-           <feature name="LEV"/>
-         </optionalConform>
-       </feature>
-       <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
-         <optionalConform>
-           <feature name="MEA"/>
-         </optionalConform>
-       </feature>
-       <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
-         <optionalConform>
-           <feature name="MEA"/>
-         </optionalConform>
-       </feature>
-     </features>
+      <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
+        <optionalConform>
+          <feature name="LEV"/>
+        </optionalConform>
+      </feature>
+      <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
+        <optionalConform>
+          <feature name="LEV"/>
+        </optionalConform>
+      </feature>
+      <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
+        <optionalConform>
+          <feature name="MEA"/>
+        </optionalConform>
+      </feature>
+      <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
+        <optionalConform>
+          <feature name="MEA"/>
+        </optionalConform>
+      </feature>
+    </features>
 
-    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
-    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
-    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">PeakMeasuredValue</attribute>
-    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">PeakMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">AverageMeasuredValue</attribute>
-    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">AverageMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">Uncertainty</attribute>
-    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">MeasurementUnit</attribute>
-    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">MeasurementMedium</attribute>
-    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">LevelValue</attribute>
+    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>PeakMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" max="604800" default="1" optional="true">
+      <description>PeakMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>AverageMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" max="604800" default="1" optional="true">
+      <description>AverageMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" optional="true">
+      <description>Uncertainty</description>
+      <optionalConform>
+        <feature name="MEA"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" optional="true">
+      <description>MeasurementUnit</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" optional="true">
+      <description>MeasurementMedium</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" default="0" optional="true">
+      <description>LevelValue</description>
+      <mandatoryConform>
+        <feature name="LEV"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 
   <cluster>
@@ -355,45 +673,98 @@ limitations under the License.
     <globalAttribute side="either" code="0xFFFD" value="3"/>
 
     <features>
-       <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
-         <optionalConform choice="a" more="true"/>
-       </feature>
-       <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
-         <optionalConform choice="a" more="true"/>
-       </feature>
-       <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
-         <optionalConform>
-           <feature name="LEV"/>
-         </optionalConform>
-       </feature>
-       <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
-         <optionalConform>
-           <feature name="LEV"/>
-         </optionalConform>
-       </feature>
-       <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
-         <optionalConform>
-           <feature name="MEA"/>
-         </optionalConform>
-       </feature>
-       <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
-         <optionalConform>
-           <feature name="MEA"/>
-         </optionalConform>
-       </feature>
-     </features>
+      <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
+        <optionalConform>
+          <feature name="LEV"/>
+        </optionalConform>
+      </feature>
+      <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
+        <optionalConform>
+          <feature name="LEV"/>
+        </optionalConform>
+      </feature>
+      <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
+        <optionalConform>
+          <feature name="MEA"/>
+        </optionalConform>
+      </feature>
+      <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
+        <optionalConform>
+          <feature name="MEA"/>
+        </optionalConform>
+      </feature>
+    </features>
 
-    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
-    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
-    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">PeakMeasuredValue</attribute>
-    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">PeakMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">AverageMeasuredValue</attribute>
-    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">AverageMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">Uncertainty</attribute>
-    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">MeasurementUnit</attribute>
-    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">MeasurementMedium</attribute>
-    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">LevelValue</attribute>
+    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>PeakMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" max="604800" default="1" optional="true">
+      <description>PeakMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>AverageMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" max="604800" default="1" optional="true">
+      <description>AverageMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" optional="true">
+      <description>Uncertainty</description>
+      <optionalConform>
+        <feature name="MEA"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" optional="true">
+      <description>MeasurementUnit</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" optional="true">
+      <description>MeasurementMedium</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" default="0" optional="true">
+      <description>LevelValue</description>
+      <mandatoryConform>
+        <feature name="LEV"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 
   <cluster>
@@ -409,45 +780,98 @@ limitations under the License.
     <globalAttribute side="either" code="0xFFFD" value="3"/>
 
     <features>
-       <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
-         <optionalConform choice="a" more="true"/>
-       </feature>
-       <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
-         <optionalConform choice="a" more="true"/>
-       </feature>
-       <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
-         <optionalConform>
-           <feature name="LEV"/>
-         </optionalConform>
-       </feature>
-       <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
-         <optionalConform>
-           <feature name="LEV"/>
-         </optionalConform>
-       </feature>
-       <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
-         <optionalConform>
-           <feature name="MEA"/>
-         </optionalConform>
-       </feature>
-       <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
-         <optionalConform>
-           <feature name="MEA"/>
-         </optionalConform>
-       </feature>
-     </features>
-
-    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
-    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
-    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">PeakMeasuredValue</attribute>
-    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">PeakMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">AverageMeasuredValue</attribute>
-    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">AverageMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">Uncertainty</attribute>
-    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">MeasurementUnit</attribute>
-    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">MeasurementMedium</attribute>
-    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">LevelValue</attribute>
+      <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
+        <optionalConform>
+          <feature name="LEV"/>
+        </optionalConform>
+      </feature>
+      <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
+        <optionalConform>
+          <feature name="LEV"/>
+        </optionalConform>
+      </feature>
+      <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
+        <optionalConform>
+          <feature name="MEA"/>
+        </optionalConform>
+      </feature>
+      <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
+        <optionalConform>
+          <feature name="MEA"/>
+        </optionalConform>
+      </feature>
+    </features>
+    
+    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>PeakMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" max="604800" default="1" optional="true">
+      <description>PeakMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>AverageMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" max="604800" default="1" optional="true">
+      <description>AverageMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" optional="true">
+      <description>Uncertainty</description>
+      <optionalConform>
+        <feature name="MEA"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" optional="true">
+      <description>MeasurementUnit</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" optional="true">
+      <description>MeasurementMedium</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" default="0" optional="true">
+      <description>LevelValue</description>
+      <mandatoryConform>
+        <feature name="LEV"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 
   <cluster>
@@ -463,45 +887,98 @@ limitations under the License.
     <globalAttribute side="either" code="0xFFFD" value="3"/>
 
     <features>
-       <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
-         <optionalConform choice="a" more="true"/>
-       </feature>
-       <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
-         <optionalConform choice="a" more="true"/>
-       </feature>
-       <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
-         <optionalConform>
-           <feature name="LEV"/>
-         </optionalConform>
-       </feature>
-       <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
-         <optionalConform>
-           <feature name="LEV"/>
-         </optionalConform>
-       </feature>
-       <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
-         <optionalConform>
-           <feature name="MEA"/>
-         </optionalConform>
-       </feature>
-       <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
-         <optionalConform>
-           <feature name="MEA"/>
-         </optionalConform>
-       </feature>
-     </features>
+      <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
+        <optionalConform>
+          <feature name="LEV"/>
+        </optionalConform>
+      </feature>
+      <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
+        <optionalConform>
+          <feature name="LEV"/>
+        </optionalConform>
+      </feature>
+      <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
+        <optionalConform>
+          <feature name="MEA"/>
+        </optionalConform>
+      </feature>
+      <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
+        <optionalConform>
+          <feature name="MEA"/>
+        </optionalConform>
+      </feature>
+    </features>
 
-    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
-    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
-    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">PeakMeasuredValue</attribute>
-    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">PeakMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">AverageMeasuredValue</attribute>
-    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">AverageMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">Uncertainty</attribute>
-    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">MeasurementUnit</attribute>
-    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">MeasurementMedium</attribute>
-    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">LevelValue</attribute>
+    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>PeakMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" max="604800" default="1" optional="true">
+      <description>PeakMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>AverageMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" max="604800" default="1" optional="true">
+      <description>AverageMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" optional="true">
+      <description>Uncertainty</description>
+      <optionalConform>
+        <feature name="MEA"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" optional="true">
+      <description>MeasurementUnit</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" optional="true">
+      <description>MeasurementMedium</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" default="0" optional="true">
+      <description>LevelValue</description>
+      <mandatoryConform>
+        <feature name="LEV"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 
   <cluster>
@@ -517,45 +994,98 @@ limitations under the License.
     <globalAttribute side="either" code="0xFFFD" value="3"/>
 
     <features>
-       <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
-         <optionalConform choice="a" more="true"/>
-       </feature>
-       <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
-         <optionalConform choice="a" more="true"/>
-       </feature>
-       <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
-         <optionalConform>
-           <feature name="LEV"/>
-         </optionalConform>
-       </feature>
-       <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
-         <optionalConform>
-           <feature name="LEV"/>
-         </optionalConform>
-       </feature>
-       <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
-         <optionalConform>
-           <feature name="MEA"/>
-         </optionalConform>
-       </feature>
-       <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
-         <optionalConform>
-           <feature name="MEA"/>
-         </optionalConform>
-       </feature>
-     </features>
+      <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
+        <optionalConform>
+          <feature name="LEV"/>
+        </optionalConform>
+      </feature>
+      <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
+        <optionalConform>
+          <feature name="LEV"/>
+        </optionalConform>
+      </feature>
+      <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
+        <optionalConform>
+          <feature name="MEA"/>
+        </optionalConform>
+      </feature>
+      <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
+        <optionalConform>
+          <feature name="MEA"/>
+        </optionalConform>
+      </feature>
+    </features>
 
-    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
-    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
-    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">PeakMeasuredValue</attribute>
-    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">PeakMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">AverageMeasuredValue</attribute>
-    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">AverageMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">Uncertainty</attribute>
-    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">MeasurementUnit</attribute>
-    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">MeasurementMedium</attribute>
-    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">LevelValue</attribute>
+    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>PeakMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" max="604800" default="1" optional="true">
+      <description>PeakMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" isNullable="true" optional="true">
+      <description>AverageMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" max="604800" default="1" optional="true">
+      <description>AverageMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" optional="true">
+      <description>Uncertainty</description>
+      <optionalConform>
+        <feature name="MEA"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" optional="true">
+      <description>MeasurementUnit</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" optional="true">
+      <description>MeasurementMedium</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" default="0" optional="true">
+      <description>LevelValue</description>
+      <mandatoryConform>
+        <feature name="LEV"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 
   <!-- Cluster Data Types -->

--- a/src/app/zap-templates/zcl/data-model/chip/content-app-observer-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/content-app-observer-cluster.xml
@@ -29,6 +29,7 @@ limitations under the License.
       <description>Upon receipt, the data field MAY be parsed and interpreted. Message encoding is specific to the Content App. A Content App MAY when possible read attributes from the Basic Information Cluster on the Observer and use this to determine the Message encoding.</description>
       <arg name="Data" type="char_string" optional="true"/>
       <arg name="EncodingHint" type="char_string" optional="false"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x01" name="ContentAppMessageResponse" optional="false" apiMaturity="provisional">
@@ -36,6 +37,7 @@ limitations under the License.
       <arg name="Status" type="StatusEnum" optional="false"/>
       <arg name="Data" type="char_string" optional="true"/>
       <arg name="EncodingHint" type="char_string" optional="true"/>
+      <mandatoryConform/>
     </command>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/content-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/content-control-cluster.xml
@@ -43,69 +43,139 @@ limitations under the License.
       </feature>
     </features>
 
-    <attribute side="server" code="0x0000" define="ENABLED" type="boolean" writable="false" optional="false">Enabled</attribute>
-    <attribute side="server" code="0x0001" define="ON_DEMAND_RATINGS" type="ARRAY" entryType="RatingNameStruct" writable="false" optional="true">OnDemandRatings</attribute>
-    <attribute side="server" code="0x0002" define="ON_DEMAND_THRESHOLD" type="char_string" length="8" writable="false" optional="true">OnDemandRatingThreshold</attribute>
-    <attribute side="server" code="0x0003" define="SCHEDULED_CONTENT_RATINGS" type="ARRAY" entryType="RatingNameStruct" writable="false" optional="true">ScheduledContentRatings</attribute>
-    <attribute side="server" code="0x0004" define="SCHEDULED_CONTENT_RATING_THRESHOLD" type="char_string" length="8" writable="false" optional="true">ScheduledContentRatingThreshold</attribute>
-    <attribute side="server" code="0x0005" define="SCREEN_DAILY_TIME" type="elapsed_s" length="86400" writable="false" optional="true">ScreenDailyTime</attribute>
-    <attribute side="server" code="0x0006" define="REMAINING_SCREEN_TIME" type="elapsed_s" length="86400" writable="false" optional="true">RemainingScreenTime</attribute>
-    <attribute side="server" code="0x0007" define="ENABLED" type="boolean" writable="false" optional="false">BlockUnrated</attribute>
+    <attribute side="server" code="0x0000" define="ENABLED" type="boolean">
+      <description>Enabled</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="ON_DEMAND_RATINGS" type="array" entryType="RatingNameStruct" optional="true">
+      <description>OnDemandRatings</description>
+      <mandatoryConform>
+        <feature name="OCR"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="ON_DEMAND_THRESHOLD" type="char_string" length="8" optional="true">
+      <description>OnDemandRatingThreshold</description>
+      <mandatoryConform>
+        <feature name="OCR"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="SCHEDULED_CONTENT_RATINGS" type="array" entryType="RatingNameStruct" optional="true">
+      <description>ScheduledContentRatings</description>
+      <mandatoryConform>
+        <feature name="SCR"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="SCHEDULED_CONTENT_RATING_THRESHOLD" type="char_string" length="8" optional="true">
+      <description>ScheduledContentRatingThreshold</description>
+      <mandatoryConform>
+        <feature name="SCR"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="SCREEN_DAILY_TIME" type="elapsed_s" optional="true" length="86400">
+      <description>ScreenDailyTime</description>
+      <mandatoryConform>
+        <feature name="ST"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="REMAINING_SCREEN_TIME" type="elapsed_s" optional="true" length="86400">
+      <description>RemainingScreenTime</description>
+      <mandatoryConform>
+        <feature name="ST"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="ENABLED" type="boolean">
+      <description>BlockUnrated</description>
+      <mandatoryConform>
+        <feature name="BU"/>
+      </mandatoryConform>
+    </attribute>
 
     <command source="client" code="0x00" name="UpdatePIN" optional="true">
       <description>The purpose of this command is to update the PIN used for protecting configuration of the content control settings. Upon success, the old PIN SHALL no longer work. The PIN is used to ensure that only the Node (or User) with the PIN code can make changes to the Content Control settings, for example, turn off Content Controls or modify the ScreenDailyTime. The PIN is composed of a numeric string of up to 6 human readable characters (displayable) . Upon receipt of this command, the media device SHALL check if the OldPIN field of this command is the same as the current PIN. If the PINs are the same, then the PIN code SHALL be set to NewPIN. Otherwise a response with InvalidPINCode error status SHALL be returned. The media device MAY provide a default PIN to the User via an out of band mechanism. For security reasons, it is recommended that a client encourage the user to update the PIN from its default value when performing configuration of the Content Control settings exposed by this cluster. The ResetPIN command can also be used to obtain the default PIN.</description>
       <arg name="OldPIN" type="char_string" max="6" optional="true"/>
       <arg name="NewPIN" type="char_string" max="6" optional="false"/>
+      <mandatoryConform>
+        <feature name="PM"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x01" name="ResetPIN" response="ResetPINResponse" optional="true">
       <description>The purpose of this command is to reset the PIN. If this command is executed successfully, a ResetPINResponse command with a new PIN SHALL be returned.</description>
+      <mandatoryConform>
+        <feature name="PM"/>
+      </mandatoryConform>
     </command>
 
     <command source="server" code="0x02" name="ResetPINResponse" optional="true">
       <description>This command SHALL be generated in response to a ResetPIN command. The data for this command SHALL be as follows:</description>
       <arg name="PINCode" type="char_string" max="6" optional="false"/>
+      <mandatoryConform>
+        <feature name="PM"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x03" name="Enable" optional="true">
       <description>The purpose of this command is to turn on the Content Control feature on a media device. On receipt of the Enable command, the media device SHALL set the Enabled attribute to TRUE.</description>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x04" name="Disable" optional="true">
       <description>The purpose of this command is to turn off the Content Control feature on a media device. On receipt of the Disable command, the media device SHALL set the Enabled attribute to FALSE.</description>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x05" name="AddBonusTime" optional="true">
       <description>The purpose of this command is to add the extra screen time for the user. If a client with Operate privilege invokes this command, the media device SHALL check whether the PINCode passed in the command matches the current PINCode value. If these match, then the RemainingScreenTime attribute SHALL be increased by the specified BonusTime value. If the PINs do not match, then a response with InvalidPINCode error status SHALL be returned, and no changes SHALL be made to RemainingScreenTime. If a client with Manage privilege or greater invokes this command, the media device SHALL ignore the PINCode field and directly increase the RemainingScreenTime attribute by the specified BonusTime value. A server that does not support the PM feature SHALL respond with InvalidPINCode to clients that only have Operate privilege unless: It has been provided with the PIN value to expect via an out of band mechanism, and The client has provided a PINCode that matches the expected PIN value.</description>
       <arg name="PINCode" type="char_string" max="6" optional="true"/>
       <arg name="BonusTime" type="elapsed_s" optional="true"/>
+      <mandatoryConform>
+        <feature name="ST"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x06" name="SetScreenDailyTime" optional="true">
       <description>The purpose of this command is to set the ScreenDailyTime attribute. On receipt of the SetScreenDailyTime command, the media device SHALL set the ScreenDailyTime attribute to the ScreenTime value.</description>
       <arg name="ScreenTime" type="elapsed_s" optional="false"/>
+      <mandatoryConform>
+        <feature name="ST"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x07" name="BlockUnratedContent" optional="true">
       <description>The purpose of this command is to specify whether programs with no Content rating must be blocked by this media device. On receipt of the BlockUnratedContent command, the media device SHALL set the BlockUnrated attribute to TRUE.</description>
+      <mandatoryConform>
+        <feature name="BU"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x08" name="UnblockUnratedContent" optional="true">
       <description>The purpose of this command is to specify whether programs with no Content rating must be blocked by this media device. On receipt of the UnblockUnratedContent command, the media device SHALL set the BlockUnrated attribute to FALSE.</description>
+      <mandatoryConform>
+        <feature name="BU"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x09" name="SetOnDemandRatingThreshold" optional="true">
       <description>The purpose of this command is to set the OnDemandRatingThreshold attribute. On receipt of the SetOnDemandRatingThreshold command, the media device SHALL check if the Rating field is one of values present in the OnDemandRatings attribute. If not, then a response with InvalidRating error status SHALL be returned.</description>
       <arg name="Rating" type="char_string" max="8" optional="false"/>
+      <mandatoryConform>
+        <feature name="OCR"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x0A" name="SetScheduledContentRatingThreshold" optional="true">
       <description>The purpose of this command is to set ScheduledContentRatingThreshold attribute. On receipt of the SetScheduledContentRatingThreshold command, the media device SHALL check if the Rating field is one of values present in the ScheduledContentRatings attribute. If not, then a response with InvalidRating error status SHALL be returned.</description>
       <arg name="Rating" type="char_string" max="8" optional="false"/>
+      <mandatoryConform>
+        <feature name="SCR"/>
+      </mandatoryConform>
     </command>
 
     <event side="server" code="0x00" priority="info" name="RemainingScreenTimeExpired" optional="true">
       <description>This event SHALL be generated when the RemainingScreenTime equals 0.</description>
+      <mandatoryConform>
+        <feature name="ST"/>
+      </mandatoryConform>
     </event>
   </cluster>
 

--- a/src/app/zap-templates/zcl/data-model/chip/content-launch-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/content-launch-cluster.xml
@@ -25,10 +25,20 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <description>This cluster provides an interface for launching content on a media player device such as a TV or Speaker.</description>
     <globalAttribute side="either" code="0xFFFD" value="1"/>
-
-    <attribute side="server" code="0x0000" define="CONTENT_LAUNCHER_ACCEPT_HEADER"                 type="array" entryType="char_string" length="254" writable="false" optional="true">AcceptHeader</attribute>
-    <attribute side="server" code="0x0001" define="CONTENT_LAUNCHER_SUPPORTED_STREAMING_PROTOCOLS" type="SupportedProtocolsBitmap" default="0"                       writable="false"  optional="true">SupportedStreamingProtocols</attribute>
-
+    
+    <attribute side="server" code="0x0000" define="CONTENT_LAUNCHER_ACCEPT_HEADER" type="array" entryType="char_string" length="254" optional="true">
+      <description>AcceptHeader</description>
+      <mandatoryConform>
+        <feature name="UP"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="CONTENT_LAUNCHER_SUPPORTED_STREAMING_PROTOCOLS" type="SupportedProtocolsBitmap" default="0" optional="true">
+      <description>SupportedStreamingProtocols</description>
+      <mandatoryConform>
+        <feature name="UP"/>
+      </mandatoryConform>
+    </attribute>
+    
     <command source="client" code="0x00" name="LaunchContent" response="LauncherResponse" optional="true">
       <description>Upon receipt, this SHALL launch the specified content with optional search criteria.</description>
       <arg name="Search" type="ContentSearchStruct"/>
@@ -36,6 +46,9 @@ limitations under the License.
       <arg name="Data" type="char_string" optional="true"/>
       <arg name="PlaybackPreferences" type="PlaybackPreferencesStruct" optional="true"/>
       <arg name="UseCurrentContext" type="boolean" optional="true"/>
+      <mandatoryConform>
+        <feature name="CS"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x01" name="LaunchURL" response="LauncherResponse" optional="true">
@@ -43,12 +56,21 @@ limitations under the License.
       <arg name="ContentURL" type="char_string"/>
       <arg name="DisplayString" type="char_string" optional="true"/>
       <arg name="BrandingInformation" type="BrandingInformationStruct" optional="true"/>
+      <mandatoryConform>
+        <feature name="UP"/>
+      </mandatoryConform>
     </command>
 
     <command source="server" code="0x02" name="LauncherResponse" optional="true" disableDefaultResponse="true">
       <description>This command SHALL be generated in response to LaunchContent command.</description>
       <arg name="Status" type="StatusEnum"/>
       <arg name="Data" type="char_string" optional="true"/>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="CS"/>
+          <feature name="UP"/>
+        </orTerm>
+      </mandatoryConform>
     </command>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/descriptor-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/descriptor-cluster.xml
@@ -44,11 +44,28 @@ limitations under the License.
     <features>
       <feature bit="0" code="TAGLIST" name="TagList" summary="The TagList attribute is present"/>
     </features>
-
-    <attribute side="server" code="0x0000" define="DEVICE_LIST" type="array" entryType="DeviceTypeStruct" writable="false" optional="false">DeviceTypeList</attribute>
-    <attribute side="server" code="0x0001" define="SERVER_LIST" type="array" entryType="cluster_id" writable="false" optional="false">ServerList</attribute>
-    <attribute side="server" code="0x0002" define="CLIENT_LIST" type="array" entryType="cluster_id" writable="false" optional="false">ClientList</attribute>
-    <attribute side="server" code="0x0003" define="PARTS_LIST" type="array" entryType="endpoint_no" writable="false" optional="false">PartsList</attribute>
-    <attribute side="server" code="0x0004" define="TAG_LIST" type="array" entryType="SemanticTagStruct" writable="false" optional="true" length="6">TagList</attribute>
+    
+    <attribute side="server" code="0x0000" define="DEVICE_LIST" type="array" entryType="DeviceTypeStruct">
+      <description>DeviceTypeList</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="SERVER_LIST" type="array" entryType="cluster_id">
+      <description>ServerList</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="CLIENT_LIST" type="array" entryType="cluster_id">
+      <description>ClientList</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="PARTS_LIST" type="array" entryType="endpoint_no">
+      <description>PartsList</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0004" define="TAG_LIST" type="array" entryType="SemanticTagStruct" optional="true" length="6">
+      <description>TagList</description>
+      <mandatoryConform>
+        <feature name="TAGLIST"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/device-energy-management-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/device-energy-management-cluster.xml
@@ -74,41 +74,95 @@ Git: 1.4-prerelease-ipr-69-ge15ff5700
       </feature>
     </features>
     <!--Attributes-->
-    <attribute code="0x0000" side="server" type="ESATypeEnum" define="ESA_TYPE" min="0x00" max="0xFF" default="0xFF">ESAType</attribute>
-    <attribute code="0x0001" side="server" type="boolean" define="ESA_CAN_GENERATE" default="0">ESACanGenerate</attribute>
-    <attribute code="0x0002" side="server" type="ESAStateEnum" define="ESA_STATE" default="0x00" min="0x00" max="0x04">ESAState</attribute>
-    <attribute code="0x0003" side="server" type="power_mw" define="ABS_MIN_POWER" default="0">AbsMinPower</attribute>
-    <attribute code="0x0004" side="server" type="power_mw" define="ABS_MAX_POWER" default="0">AbsMaxPower</attribute>
+    <attribute code="0x0000" side="server" type="ESATypeEnum" define="ESA_TYPE" min="0x00" max="0xFF" default="0xFF">
+      <description>ESAType</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute code="0x0001" side="server" type="boolean" define="ESA_CAN_GENERATE" default="0">
+      <description>ESACanGenerate</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute code="0x0002" side="server" type="ESAStateEnum" define="ESA_STATE" default="0x00" min="0x00" max="0x04">
+      <description>ESAState</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute code="0x0003" side="server" type="power_mw" define="ABS_MIN_POWER" default="0">
+      <description>AbsMinPower</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute code="0x0004" side="server" type="power_mw" define="ABS_MAX_POWER" default="0">
+      <description>AbsMaxPower</description>
+      <mandatoryConform/>
+    </attribute>
     <!--Conformance feature PA - for now optional-->
-    <attribute code="0x0005" side="server" type="PowerAdjustCapabilityStruct" define="POWER_ADJUSTMENT_CAPABILITY" isNullable="true" optional="true">PowerAdjustmentCapability</attribute>
+    <attribute code="0x0005" side="server" type="PowerAdjustCapabilityStruct" define="POWER_ADJUSTMENT_CAPABILITY" isNullable="true" optional="true">
+      <description>PowerAdjustmentCapability</description>
+      <mandatoryConform>
+        <feature name="PA"/>
+      </mandatoryConform>
+    </attribute>
     <!--Conformance feature PFR \| SFR - for now optional-->
-    <attribute code="0x0006" side="server" type="ForecastStruct" define="FORECAST" isNullable="true" optional="true">Forecast</attribute>
-    <attribute code="0x0007" side="server" type="OptOutStateEnum" define="OPT_OUT_STATE" min="0x00" max="0x03" default="0x00" optional="true">OptOutState</attribute>
+    <attribute code="0x0006" side="server" type="ForecastStruct" define="FORECAST" isNullable="true" optional="true">
+      <description>Forecast</description>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="PFR"/>
+          <feature name="SFR"/>
+        </orTerm>
+      </mandatoryConform>
+    </attribute>
+    <attribute code="0x0007" side="server" type="OptOutStateEnum" define="OPT_OUT_STATE" min="0x00" max="0x03" default="0x00" optional="true">
+      <description>OptOutState</description>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="PA"/>
+          <feature name="STA"/>
+          <feature name="PAU"/>
+          <feature name="FA"/>
+          <feature name="CON"/>
+        </orTerm>
+      </mandatoryConform>
+    </attribute>
     <command source="client" code="0x00" name="PowerAdjustRequest" optional="true" apiMaturity="provisional">
       <description>Allows a client to request an adjustment in the power consumption of an ESA for a specified duration.</description>
       <arg id="0" name="Power" type="power_mw"/>
       <arg id="1" name="Duration" type="elapsed_s"/>
       <arg id="2" name="Cause" type="AdjustmentCauseEnum" min="0x00" max="0x01"/>
+      <mandatoryConform>
+        <feature name="PA"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x01" name="CancelPowerAdjustRequest" optional="true" apiMaturity="provisional">
       <description>Allows a client to cancel an ongoing PowerAdjustmentRequest operation.</description>
+      <mandatoryConform>
+        <feature name="PA"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x02" name="StartTimeAdjustRequest" optional="true" apiMaturity="provisional">
       <description>Allows a client to adjust the start time of a Forecast sequence that has not yet started operation (i.e. where the current Forecast StartTime is in the future).</description>
       <arg id="0" name="RequestedStartTime" type="epoch_s"/>
       <arg id="1" name="Cause" type="AdjustmentCauseEnum" min="0x00" max="0x01"/>
+      <mandatoryConform>
+        <feature name="STA"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x03" name="PauseRequest" optional="true" apiMaturity="provisional">
       <description>Allows a client to temporarily pause an operation and reduce the ESAs energy demand.</description>
       <arg id="0" name="Duration" type="elapsed_s"/>
       <arg id="1" name="Cause" type="AdjustmentCauseEnum" min="0x00" max="0x01"/>
+      <mandatoryConform>
+        <feature name="PAU"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x04" name="ResumeRequest" optional="true" apiMaturity="provisional">
       <description>Allows a client to cancel the PauseRequest command and enable earlier resumption of operation.</description>
+      <mandatoryConform>
+        <feature name="PAU"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x05" name="ModifyForecastRequest" optional="true" apiMaturity="provisional">
@@ -116,20 +170,36 @@ Git: 1.4-prerelease-ipr-69-ge15ff5700
       <arg id="0" name="ForecastID" type="int32u"/>
       <arg id="1" name="SlotAdjustments" array="true" type="SlotAdjustmentStruct" length="10"/>
       <arg id="2" name="Cause" type="AdjustmentCauseEnum" min="0x00" max="0x01"/>
+      <mandatoryConform>
+        <feature name="FA"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x06" name="RequestConstraintBasedForecast" optional="true" apiMaturity="provisional">
       <description>Allows a client to ask the ESA to recompute its Forecast based on power and time constraints.</description>
       <arg id="0" name="Constraints" array="true" type="ConstraintsStruct" length="10"/>
       <arg id="1" name="Cause" type="AdjustmentCauseEnum" min="0x00" max="0x01"/>
+      <mandatoryConform>
+        <feature name="CON"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x07" name="CancelRequest" optional="true">
       <description>Allows a client to request cancellation of a previous adjustment request in a StartTimeAdjustRequest, ModifyForecastRequest or RequestConstraintBasedForecast command.</description>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="STA"/>
+          <feature name="FA"/>
+          <feature name="CON"/>
+        </orTerm>
+      </mandatoryConform>
     </command>
 
     <event code="0x00" name="PowerAdjustStart" priority="info" side="server" apiMaturity="provisional" optional="true">
       <description>This event SHALL be generated when the Power Adjustment session is started.</description>
+      <mandatoryConform>
+        <feature name="PA"/>
+      </mandatoryConform>
     </event>
 
     <event code="0x01" name="PowerAdjustEnd" priority="info" side="server" apiMaturity="provisional" optional="true">
@@ -137,15 +207,24 @@ Git: 1.4-prerelease-ipr-69-ge15ff5700
       <field id="0" name="Cause" type="CauseEnum" apiMaturity="provisional" default="0x00" min="0x00" max="0x04"/>
       <field id="1" name="Duration" type="elapsed_s" apiMaturity="provisional"/>
       <field id="2" name="EnergyUse" type="energy_mwh" apiMaturity="provisional"/>
+      <mandatoryConform>
+        <feature name="PA"/>
+      </mandatoryConform>
     </event>
 
     <event code="0x02" name="Paused" priority="info" side="server" apiMaturity="provisional" optional="true">
       <description>This event SHALL be generated when the ESA enters the Paused state.</description>
+      <mandatoryConform>
+        <feature name="PAU"/>
+      </mandatoryConform>
     </event>
 
     <event code="0x03" name="Resumed" priority="info" side="server" apiMaturity="provisional" optional="true">
       <description>This event SHALL be generated when the ESA leaves the Paused state and resumes operation.</description>
       <field id="0" name="Cause" type="CauseEnum" apiMaturity="provisional" default="0x00" min="0x00" max="0x04"/>
+      <mandatoryConform>
+        <feature name="PAU"/>
+      </mandatoryConform>
     </event>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/device-energy-management-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/device-energy-management-mode-cluster.xml
@@ -59,18 +59,26 @@ Git: 1.4-prerelease-ipr-69-ge15ff5700
       </feature>
     </features>
     <!-- Base data types -->
-    <attribute side="server" code="0x0000" define="SUPPORTED_MODES" type="array" entryType="ModeOptionStruct" length="255" minLength="2">SupportedModes</attribute>
-    <attribute side="server" code="0x0001" define="CURRENT_MODE" type="int8u">CurrentMode</attribute>
+    <attribute side="server" code="0x0000" define="SUPPORTED_MODES" type="array" entryType="ModeOptionStruct" length="255" minLength="2">
+      <description>SupportedModes</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="CURRENT_MODE" type="int8u">
+      <description>CurrentMode</description>
+      <mandatoryConform/>
+    </attribute>
     <!-- Commands -->
     <command source="client" code="0x00" name="ChangeToMode" response="ChangeToModeResponse" optional="false">
       <description>This command is used to change device modes.</description>
       <arg id="0" name="NewMode" type="int8u"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x01" name="ChangeToModeResponse" disableDefaultResponse="true" optional="false">
       <description>This command is sent by the device on receipt of the ChangeToMode command.</description>
       <arg id="0" name="Status" type="enum8"/>
       <arg id="1" name="StatusText" type="char_string" length="64" optional="true"/>
+      <mandatoryConform/>
     </command>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/diagnostic-logs-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/diagnostic-logs-cluster.xml
@@ -15,46 +15,48 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <configurator>
-    <domain name="CHIP" spec="chip-0.7" dependsOn="zcl-1.0-07-5123-03" certifiable="true"/>
-    <enum name="IntentEnum" type="enum8">
-        <cluster code="0x0032"/>
-        <item name="EndUserSupport" value="0x0"/>
-        <item name="NetworkDiag" value="0x1"/>
-        <item name="CrashLogs" value="0x2"/>
-    </enum>
-    <enum name="StatusEnum" type="enum8">
-        <cluster code="0x0032"/>
-        <item name="Success" value="0x0"/>
-        <item name="Exhausted" value="0x1"/>
-        <item name="NoLogs" value="0x2"/>
-        <item name="Busy" value="0x3"/>
-        <item name="Denied" value="0x4"/>
-    </enum>
-    <enum name="TransferProtocolEnum" type="enum8">
-        <cluster code="0x0032"/>
-        <item name="ResponsePayload" value="0x0"/>
-        <item name="BDX" value="0x1"/>
-    </enum>
-    <cluster>
-        <name>Diagnostic Logs</name>
-        <domain>CHIP</domain>
-        <description>The cluster provides commands for retrieving unstructured diagnostic logs from a Node that may be used to aid in diagnostics.</description>
-        <code>0x0032</code>
-        <define>DIAGNOSTIC_LOGS_CLUSTER</define>
-        <client tick="false" init="false">true</client>
-        <server tick="false" init="false">true</server>
-        <command source="client" code="0x00" name="RetrieveLogsRequest" response="RetrieveLogsResponse" optional="false" cli="chip logs retrieve">
-            <description>Retrieving diagnostic logs from a Node</description>
-            <arg name="Intent" type="IntentEnum"/>
-            <arg name="RequestedProtocol" type="TransferProtocolEnum"/>
-            <arg name="TransferFileDesignator" type="char_string" length="32" optional="true"/>
-        </command>
-        <command source="server" code="0x01" name="RetrieveLogsResponse" optional="false" cli="chip logs response">
-            <description>Response to the RetrieveLogsRequest</description>
-            <arg name="Status" type="StatusEnum"/>
-            <arg name="LogContent" type="long_octet_string"/>
-            <arg name="UTCTimeStamp" type="epoch_us" optional="true"/>
-            <arg name="TimeSinceBoot" type="systime_us" optional="true"/>
-        </command>
-    </cluster>
+  <domain name="CHIP" spec="chip-0.7" dependsOn="zcl-1.0-07-5123-03" certifiable="true"/>
+  <enum name="IntentEnum" type="enum8">
+    <cluster code="0x0032"/>
+    <item name="EndUserSupport" value="0x0"/>
+    <item name="NetworkDiag" value="0x1"/>
+    <item name="CrashLogs" value="0x2"/>
+  </enum>
+  <enum name="StatusEnum" type="enum8">
+    <cluster code="0x0032"/>
+    <item name="Success" value="0x0"/>
+    <item name="Exhausted" value="0x1"/>
+    <item name="NoLogs" value="0x2"/>
+    <item name="Busy" value="0x3"/>
+    <item name="Denied" value="0x4"/>
+  </enum>
+  <enum name="TransferProtocolEnum" type="enum8">
+    <cluster code="0x0032"/>
+    <item name="ResponsePayload" value="0x0"/>
+    <item name="BDX" value="0x1"/>
+  </enum>
+  <cluster>
+    <name>Diagnostic Logs</name>
+    <domain>CHIP</domain>
+    <description>The cluster provides commands for retrieving unstructured diagnostic logs from a Node that may be used to aid in diagnostics.</description>
+    <code>0x0032</code>
+    <define>DIAGNOSTIC_LOGS_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <command source="client" code="0x00" name="RetrieveLogsRequest" response="RetrieveLogsResponse" optional="false" cli="chip logs retrieve">
+      <description>Retrieving diagnostic logs from a Node</description>
+      <arg name="Intent" type="IntentEnum"/>
+      <arg name="RequestedProtocol" type="TransferProtocolEnum"/>
+      <arg name="TransferFileDesignator" type="char_string" length="32" optional="true"/>
+      <mandatoryConform/>
+    </command>
+    <command source="server" code="0x01" name="RetrieveLogsResponse" optional="false" cli="chip logs response">
+      <description>Response to the RetrieveLogsRequest</description>
+      <arg name="Status" type="StatusEnum"/>
+      <arg name="LogContent" type="long_octet_string"/>
+      <arg name="UTCTimeStamp" type="epoch_us" optional="true"/>
+      <arg name="TimeSinceBoot" type="systime_us" optional="true"/>
+      <mandatoryConform/>
+    </command>
+  </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/dishwasher-alarm-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/dishwasher-alarm-cluster.xml
@@ -43,27 +43,46 @@ limitations under the License.
       </feature>
     </features>
 
-    <attribute side="server" code="0x0000" define="MASK"      type="AlarmBitmap" default="0" writable="false" optional="false">Mask</attribute>
-    <attribute side="server" code="0x0001" define="LATCH"     type="AlarmBitmap" default="0" writable="false" optional="true">Latch</attribute>
-    <attribute side="server" code="0x0002" define="STATE"     type="AlarmBitmap" default="0" writable="false" optional="false">State</attribute>
-    <attribute side="server" code="0x0003" define="SUPPORTED" type="AlarmBitmap" default="0" writable="false" optional="false">Supported</attribute>
+    <attribute side="server" code="0x0000" define="MASK" type="AlarmBitmap" default="0">
+      <description>Mask</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="LATCH" type="AlarmBitmap" default="0" optional="true">
+      <description>Latch</description>
+      <mandatoryConform>
+        <feature name="RESET"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="STATE" type="AlarmBitmap" default="0">
+      <description>State</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="SUPPORTED" type="AlarmBitmap" default="0">
+      <description>Supported</description>
+      <mandatoryConform/>
+    </attribute>
 
     <command source="client" code="0x00" name="Reset" optional="true">
-        <description>Reset alarm</description>
-        <arg name="Alarms" type="AlarmBitmap" optional="false"/>
+      <description>Reset alarm</description>
+      <arg name="Alarms" type="AlarmBitmap" optional="false"/>
+      <mandatoryConform>
+        <feature name="RESET"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x01" name="ModifyEnabledAlarms" optional="true">
-        <description>Modify enabled alarms</description>
-        <arg name="Mask" type="AlarmBitmap" optional="false"/>
+      <description>Modify enabled alarms</description>
+      <arg name="Mask" type="AlarmBitmap" optional="false"/>
+      <optionalConform/>
     </command>
 
     <event side="server" code="0x00" priority="info" name="Notify" optional="false">
-        <description>Notify</description>
-        <field id="0" name="Active" type="AlarmBitmap" />
-        <field id="1" name="Inactive" type="AlarmBitmap" />
-        <field id="2" name="State" type="AlarmBitmap" />
-        <field id="3" name="Mask" type="AlarmBitmap" />
+      <description>Notify</description>
+      <field id="0" name="Active" type="AlarmBitmap"/>
+      <field id="1" name="Inactive" type="AlarmBitmap"/>
+      <field id="2" name="State" type="AlarmBitmap"/>
+      <field id="3" name="Mask" type="AlarmBitmap"/>
+      <mandatoryConform/>
     </event>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/dishwasher-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/dishwasher-mode-cluster.xml
@@ -57,11 +57,17 @@ limitations under the License.
     </features>
 
     <!-- Base data types -->
-    <attribute side="server" code="0x0000" define="SUPPORTED_MODES"  type="array" entryType="ModeOptionStruct" writable="false" optional="false" isNullable="false" length="255">SupportedModes</attribute>
-    <attribute side="server" code="0x0001" define="CURRENT_MODE"     type="int8u"                              writable="false" optional="false" isNullable="false" reportable="true">CurrentMode</attribute>
+    <attribute side="server" code="0x0000" define="SUPPORTED_MODES" type="array" entryType="ModeOptionStruct" length="255">
+      <description>SupportedModes</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="CURRENT_MODE" type="int8u" reportable="true">
+      <description>CurrentMode</description>
+      <mandatoryConform/>
+    </attribute>
     <attribute side="server" code="0x0002" define="START_UP_MODE"    type="int8u"                              writable="true"  optional="true"  isNullable="true">StartUpMode</attribute>
     <attribute side="server" code="0x0003" define="ON_MODE"          type="int8u"                              writable="true"  optional="true"  isNullable="true">OnMode</attribute>
-
+    
     <!-- Commands -->
     <command source="client" code="0x00" name="ChangeToMode" response="ChangeToModeResponse" optional="false">
       <description>
@@ -69,6 +75,7 @@ limitations under the License.
         On receipt of this command the device SHALL respond with a ChangeToModeResponse command.
       </description>
       <arg name="NewMode" type="int8u" optional="false"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x01" name="ChangeToModeResponse" disableDefaultResponse="true" optional="false">
@@ -77,6 +84,7 @@ limitations under the License.
       </description>
       <arg name="Status"     type="enum8"                   optional="false"/>
       <arg name="StatusText" type="char_string" lenght="64" optional="true"/>
+      <mandatoryConform/>
     </command>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/door-lock-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/door-lock-cluster.xml
@@ -131,659 +131,901 @@ limitations under the License.
          3. Everything that depends on a certain feature is optional because we have no way
             of setting up the dependencies here. Dependencies would be probably resolved in the
             cluster itself. Those attributes/commands are marked with a special comment. -->
+    
+    <!-- Attributes -->
+    <attribute side="server" code="0" define="LOCK_STATE" type="DlLockState" min="0" max="3" isNullable="true" reportable="true">
+      <description>LockState</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="1" define="LOCK_TYPE" type="DlLockType" min="0" max="11">
+      <description>LockType</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="2" define="ACTUATOR_ENABLED" type="boolean">
+      <description>ActuatorEnabled</description>
+      <mandatoryConform/>
+    </attribute>
+    <!-- Conformance feature DPS - for now optional -->
+    <attribute side="server" code="3" define="DOOR_STATE" type="DoorStateEnum" min="0" max="5" isNullable="true" reportable="true" optional="true">
+      <description>DoorState</description>
+      <mandatoryConform>
+        <feature name="DPS"/>
+      </mandatoryConform>
+    </attribute>
+    <!-- Conformance feature [DPS] - for now optional -->
+    <attribute side="server" code="4" define="DOOR_OPEN_EVENTS" type="int32u" writable="true" optional="true">
+      <description>DoorOpenEvents</description>
+      <access op="read" role="view" />
+      <access op="write" role="manage"/>
+      <optionalConform>
+        <feature name="DPS"/>
+      </optionalConform>
+    </attribute>
+    <!-- Conformance feature [DPS] - for now optional -->
+    <attribute side="server" code="5" define="DOOR_CLOSED_EVENTS" type="int32u" writable="true" optional="true">
+      <description>DoorClosedEvents</description>
+      <access op="read" role="view" />
+      <access op="write" role="manage"/>
+      <optionalConform>
+        <feature name="DPS"/>
+      </optionalConform>
+    </attribute>
+    <!-- Conformance feature [DPS] - for now optional -->
+    <attribute side="server" code="6" define="OPEN_PERIOD" type="int16u" writable="true" optional="true">
+      <description>OpenPeriod</description>
+      <access op="read" role="view" />
+      <access op="write" role="manage"/>
+      <optionalConform>
+        <feature name="DPS"/>
+      </optionalConform>
+    </attribute>
+    <!-- Conformance feature USR - for now optional -->
+    <attribute side="server" code="17" define="NUM_TOTAL_USERS_SUPPORTED" type="int16u" default="0" optional="true">
+      <description>NumberOfTotalUsersSupported</description>
+      <mandatoryConform>
+        <feature name="USR"/>
+      </mandatoryConform>
+    </attribute>
+    <!-- Conformance feature PIN - for now optional -->
+    <attribute side="server" code="18" define="NUM_PIN_USERS_SUPPORTED" type="int16u" default="0" optional="true">
+      <description>NumberOfPINUsersSupported</description>
+      <mandatoryConform>
+        <feature name="PIN"/>
+      </mandatoryConform>
+    </attribute>
+    <!-- Conformance feature RFID - for now optional -->
+    <attribute side="server" code="19" define="NUM_RFID_USERS_SUPPORTED" type="int16u" default="0" optional="true">
+      <description>NumberOfRFIDUsersSupported</description>
+      <mandatoryConform>
+        <feature name="RID"/>
+      </mandatoryConform>
+    </attribute>
+    <!-- Conformance feature WDSCH - for now optional -->
+    <attribute side="server" code="20" define="NUM_WEEKDAY_SCHEDULES_SUPPORTED_PER_USER" type="int8u" default="0" optional="true">
+      <description>NumberOfWeekDaySchedulesSupportedPerUser</description>
+      <mandatoryConform>
+        <feature name="WDSCH"/>
+      </mandatoryConform>
+    </attribute>
+    <!-- Conformance feature YDSCH - for now optional -->
+    <attribute side="server" code="21" define="NUM_YEARDAY_SCHEDULES_SUPPORTED_PER_USER" type="int8u" default="0" optional="true">
+      <description>NumberOfYearDaySchedulesSupportedPerUser</description>
+      <mandatoryConform>
+        <feature name="YDSCH"/>
+      </mandatoryConform>
+    </attribute>
+    <!-- Conformance feature HDSCH - for now optional -->
+    <attribute side="server" code="22" define="NUM_HOLIDAY_SCHEDULES_SUPPORTED" type="int8u" default="0" optional="true">
+      <description>NumberOfHolidaySchedulesSupported</description>
+      <mandatoryConform>
+        <feature name="HDSCH"/>
+      </mandatoryConform>
+    </attribute>
+    <!-- Conformance feature PIN - for now optional -->
+    <attribute side="server" code="23" define="MAX_PIN_LENGTH" type="int8u" optional="true">
+      <description>MaxPINCodeLength</description>
+      <mandatoryConform>
+        <feature name="PIN"/>
+      </mandatoryConform>
+    </attribute>
+    <!-- Conformance feature PIN - for now optional -->
+    <attribute side="server" code="24" define="MIN_PIN_LENGTH" type="int8u" optional="true">
+      <description>MinPINCodeLength</description>
+      <mandatoryConform>
+        <feature name="PIN"/>
+      </mandatoryConform>
+    </attribute>
+    <!-- Conformance feature RID - for now optional -->
+    <attribute side="server" code="25" define="MAX_RFID_CODE_LENGTH" type="int8u" optional="true">
+      <description>MaxRFIDCodeLength</description>
+      <mandatoryConform>
+        <feature name="RID"/>
+      </mandatoryConform>
+    </attribute>
+    <!-- Conformance feature RID - for now optional -->
+    <attribute side="server" code="26" define="MIN_RFID_CODE_LENGTH" type="int8u" optional="true">
+      <description>MinRFIDCodeLength</description>
+      <mandatoryConform>
+        <feature name="RID"/>
+      </mandatoryConform>
+    </attribute>
+    <!-- Conformance feature USR - for now optional -->
+    <attribute side="server" code="27" define="CREDENTIAL_RULES_SUPPORT" type="DlCredentialRuleMask" min="0x00" max="0xFF" default="1" optional="true">
+      <description>CredentialRulesSupport</description>
+      <mandatoryConform>
+        <feature name="USR"/>
+      </mandatoryConform>
+    </attribute>
+    <!-- Conformance feature USR - for now optional  -->
+    <attribute side="server" code="28" define="NUM_CREDENTIALS_SUPPORTED_PER_USER" type="int8u" default="0" optional="true">
+      <description>NumberOfCredentialsSupportedPerUser</description>
+      <mandatoryConform>
+        <feature name="USR"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="33" define="LANGUAGE" type="char_string" length="3" reportable="true" writable="true" optional="true">
+      <description>Language</description>
+      <access op="read" role="view" />
+      <access op="write" role="manage"/>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="34" define="LED_SETTINGS" type="int8u" min="0" max="2" reportable="true" default="0" writable="true" optional="true">
+      <description>LEDSettings</description>
+      <access op="read" role="view" />
+      <access op="write" role="manage"/>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="35" define="AUTO_RELOCK_TIME" type="int32u" reportable="true" writable="true" optional="true">
+      <description>AutoRelockTime</description>
+      <access op="read" role="view" />
+      <access op="write" role="manage"/>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="36" define="SOUND_VOLUME" type="int8u" min="0" max="3" reportable="true" default="0" writable="true" optional="true">
+      <description>SoundVolume</description>
+      <access op="read" role="view" />
+      <access op="write" role="manage"/>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="37" define="OPERATING_MODE" type="OperatingModeEnum" min="0" max="4" reportable="true" writable="true">
+      <description>OperatingMode</description>
+      <access op="read" role="view" />
+      <access op="write" role="manage"/>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="38" define="SUPPORTED_OPERATING_MODES" type="DlSupportedOperatingModes" min="0x0000" max="0xFFFF" default="0xFFF6">
+      <description>SupportedOperatingModes</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="39" define="DEFAULT_CONFIGURATION_REGISTER" type="DlDefaultConfigurationRegister" min="0x0000" max="0xFFFF" reportable="true" default="0" optional="true">
+      <description>DefaultConfigurationRegister</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="40" define="ENABLE_LOCAL_PROGRAMMING" type="boolean" reportable="true" default="1" writable="true" optional="true">
+      <description>EnableLocalProgramming</description>
+      <access op="read" role="view" />
+      <access op="write" role="administer"/>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="41" define="ENABLE_ONE_TOUCH_LOCKING" type="boolean" reportable="true" default="0" writable="true" optional="true">
+      <description>EnableOneTouchLocking</description>
+      <access op="read" role="view" />
+      <access op="write" role="manage"/>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="42" define="ENABLE_INSIDE_STATUS_LED" type="boolean" reportable="true" default="0" writable="true" optional="true">
+      <description>EnableInsideStatusLED</description>
+      <access op="read" role="view" />
+      <access op="write" role="manage"/>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="43" define="ENABLE_PRIVACY_MODE_BUTTON" type="boolean" reportable="true" default="0" writable="true" optional="true">
+      <description>EnablePrivacyModeButton</description>
+      <access op="read" role="view" />
+      <access op="write" role="manage"/>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="44" define="LOCAL_PROGRAMMING_FEATURES" type="DlLocalProgrammingFeatures" min="0x0" max="0x0F" reportable="true" default="0" writable="true" optional="true">
+      <description>LocalProgrammingFeatures</description>
+      <access op="read" role="view" />
+      <access op="write" role="administer"/>
+      <optionalConform/>
+    </attribute>
+    <!-- Conformance feature PIN | RID - for now optional -->
+    <attribute side="server" code="48" define="WRONG_CODE_ENTRY_LIMIT" type="int8u" min="1" max="255" reportable="true" writable="true" optional="true">
+      <description>WrongCodeEntryLimit</description>
+      <access op="read" role="view" />
+      <access op="write" role="administer"/>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="PIN"/>
+          <feature name="RID"/>
+        </orTerm>
+      </mandatoryConform>
+    </attribute>
+    <!-- Conformance feature PIN | RID - for now optional -->
+    <attribute side="server" code="49" define="USER_CODE_TEMPORARY_DISABLE_TIME" type="int8u" min="1" max="255" reportable="true" writable="true" optional="true">
+      <description>UserCodeTemporaryDisableTime</description>
+      <access op="read" role="view" />
+      <access op="write" role="administer"/>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="PIN"/>
+          <feature name="RID"/>
+        </orTerm>
+      </mandatoryConform>
+    </attribute>
+    <!-- Conformance feature [PIN] - for now optional -->
+    <attribute side="server" code="50" define="SEND_PIN_OVER_THE_AIR" type="boolean" reportable="true" default="0" writable="true" optional="true">
+      <description>SendPINOverTheAir</description>
+      <access op="read" role="view" />
+      <access op="write" role="administer"/>
+      <optionalConform>
+        <andTerm>
+          <notTerm>
+            <feature name="USR"/>
+          </notTerm>
+          <feature name="PIN"/>
+        </andTerm>
+      </optionalConform>
+    </attribute>
+    <!-- Conformance feature COTA & PIN - for now optional -->
+    <attribute side="server" code="51" define="REQUIRE_PIN_FOR_REMOTE_OPERATION" type="boolean" reportable="true" default="0" writable="true" optional="true">
+      <description>RequirePINforRemoteOperation</description>
+      <access op="read" role="view" />
+      <access op="write" role="administer"/>
+      <mandatoryConform>
+        <andTerm>
+          <feature name="COTA"/>
+          <feature name="PIN"/>
+        </andTerm>
+      </mandatoryConform>
+    </attribute>
+    <!-- Attribute SecurityLevel with code 52 is deprecated -->
+    <!-- Conformance feature [USR] - for now optional -->
+    <attribute side="server" code="53" define="EXPIRING_USER_TIMEOUT" type="int16u" min="1" max="2880" reportable="true" writable="true" optional="true">
+      <description>ExpiringUserTimeout</description>
+      <access op="read" role="view" />
+      <access op="write" role="administer"/>
+      <optionalConform>
+        <feature name="USR"/>
+      </optionalConform>
+    </attribute>
+    <!-- Conformance feature [ALIRO] - optional -->
+    <attribute side="server" code="128" define="ALIRO_READER_VERIFICATION_KEY" type="octet_string" length="65" optional="true" isNullable="true" apiMaturity="provisional">
+      <description>AliroReaderVerificationKey</description>
+      <access op="read" privilege="administer"/>
+      <mandatoryConform>
+        <feature name="ALIRO"/>
+      </mandatoryConform>
+    </attribute>
+    <!-- Conformance feature [ALIRO] - optional -->
+    <attribute side="server" code="129" define="ALIRO_READER_GROUP_IDENTIFIER" type="octet_string" length="16" optional="true" isNullable="true" apiMaturity="provisional">
+      <description>AliroReaderGroupIdentifier</description>
+      <access op="read" privilege="administer"/>
+      <mandatoryConform>
+        <feature name="ALIRO"/>
+      </mandatoryConform>
+    </attribute>
+    <!-- Conformance feature [ALIRO] - optional -->
+    <attribute side="server" code="130" define="ALIRO_READER_GROUP_SUBIDENTIFIER" type="octet_string" length="16" optional="true" apiMaturity="provisional">
+      <description>AliroReaderGroupSubIdentifier</description>
+      <access op="read" privilege="administer"/>
+      <mandatoryConform>
+        <feature name="ALIRO"/>
+      </mandatoryConform>
+    </attribute>
+    <!-- Conformance feature [ALIRO] - optional -->
+    <attribute side="server" code="131" define="ALIRO_EXPEDITED_TRANSACTION_SUPPORTED_PROTOCOL_VERSIONS" type="array" entryType="octet_string" length="16" optional="true" apiMaturity="provisional">
+      <description>AliroExpeditedTransactionSupportedProtocolVersions</description>
+      <access op="read" privilege="administer"/>
+      <mandatoryConform>
+        <feature name="ALIRO"/>
+      </mandatoryConform>
+    </attribute>
+    <!-- Conformance feature [ALBU] - optional if ALIRO is supported -->
+    <attribute side="server" code="132" define="ALIRO_GROUP_RESOLVING_KEY" type="octet_string" length="16" optional="true" isNullable="true" apiMaturity="provisional">
+      <description>AliroGroupResolvingKey</description>
+      <access op="read" privilege="administer"/>
+      <mandatoryConform>
+        <feature name="ALBU"/>
+      </mandatoryConform>
+    </attribute>
+    <!-- Conformance feature [ALBU] - optional if ALIRO is supported -->
+    <attribute side="server" code="133" define="ALIRO_SUPPORTED_BLE_UWB_PROTOCOL_VERSIONS" type="array" entryType="octet_string" length="16" optional="true" apiMaturity="provisional">
+      <description>AliroSupportedBLEUWBProtocolVersions</description>
+      <access op="read" privilege="administer"/>
+      <mandatoryConform>
+        <feature name="ALBU"/>
+      </mandatoryConform>
+    </attribute>
+    <!-- Conformance feature [ALBU] - optional if ALIRO is supported -->
+    <attribute side="server" code="134" define="ALIRO_BLE_ADVERTISING_VERSION" type="int8u" optional="true" apiMaturity="provisional">
+      <description>AliroBLEAdvertisingVersion</description>
+      <access op="read" privilege="administer"/>
+      <mandatoryConform>
+        <feature name="ALBU"/>
+      </mandatoryConform>
+    </attribute>
+    <!-- Conformance feature [ALIRO] - optional -->
+    <attribute side="server" code="135" define="NUMBER_OF_ALIRO_CREDENTIAL_ISSUER_KEYS_SUPPORTED" type="int16u" optional="true" apiMaturity="provisional">
+      <description>NumberOfAliroCredentialIssuerKeysSupported</description>
+      <mandatoryConform>
+        <feature name="ALIRO"/>
+      </mandatoryConform>
+    </attribute>
+    <!-- Conformance feature [ALIRO] - optional -->
+    <attribute side="server" code="136" define="NUMBER_OF_ALIRO_ENDPOINT_KEYS_SUPPORTED" type="int16u" optional="true" apiMaturity="provisional">
+      <description>NumberOfAliroEndpointKeysSupported</description>
+      <mandatoryConform>
+        <feature name="ALIRO"/>
+      </mandatoryConform>
+    </attribute>
+    <!-- Commands -->
+    <command source="client" code="0" name="LockDoor" mustUseTimedInvoke="true">
+      <description>This command causes the lock device to lock the door.</description>
+      <!-- Conformance feature [COTA & PIN] - for now optional -->
+      <arg name="PINCode" type="octet_string" optional="true"/>
+      <mandatoryConform/>
+    </command>
+    <command source="client" code="1" name="UnlockDoor" mustUseTimedInvoke="true">
+      <description>This command causes the lock device to unlock the door.</description>
+      <!-- Conformance feature [COTA & PIN] - for now optional -->
+      <arg name="PINCode" type="octet_string" optional="true"/>
+      <mandatoryConform/>
+    </command>
+    <!-- Command Toggle with ID 2 is deprecated/disallowed -->
+    <command source="client" code="3" name="UnlockWithTimeout" mustUseTimedInvoke="true" optional="true">
+      <description>This command causes the lock device to unlock the door with a timeout parameter.</description>
+      <arg name="Timeout" type="int16u"/>
+      <!-- Conformance feature [COTA & PIN] - for now optional -->
+      <arg name="PINCode" type="octet_string" optional="true"/>
+      <optionalConform/>
+    </command>
+    <!-- Conformance feature WDSCH - for now optional -->
+    <command source="client" code="11" name="SetWeekDaySchedule" optional="true">
+      <description>Set a weekly repeating schedule for a specified user.</description>
+      <access op="invoke" role="administer"/>
+      <arg name="WeekDayIndex" type="int8u" />
+      <arg name="UserIndex" type="int16u" />
+      <arg name="DaysMask" type="DaysMaskMap" />
+      <arg name="StartHour" type="int8u" />
+      <arg name="StartMinute" type="int8u" />
+      <arg name="EndHour" type="int8u" />
+      <arg name="EndMinute" type="int8u" />
+      <mandatoryConform>
+        <feature name="WDSCH"/>
+      </mandatoryConform>
+    </command>
+    <!-- Conformance feature WDSCH - for now optional -->
+    <command source="client" code="12" name="GetWeekDaySchedule" response="GetWeekDayScheduleResponse" optional="true">
+      <description>Retrieve the specific weekly schedule for the specific user.</description>
+      <access op="invoke" role="administer"/>
+      <arg name="WeekDayIndex" type="int8u" />
+      <arg name="UserIndex" type="int16u" />
+      <mandatoryConform>
+        <feature name="WDSCH"/>
+      </mandatoryConform>
+    </command>
+    <!-- Conformance feature WDSCH - for now optional -->
+    <command source="server" code="12" name="GetWeekDayScheduleResponse" disableDefaultResponse="true" optional="true">
+      <description>Returns the weekly repeating schedule data for the specified schedule index.</description>
+      <arg name="WeekDayIndex" type="int8u" />
+      <arg name="UserIndex" type="int16u" />
+      <arg name="Status" type="DlStatus" />
+      <arg name="DaysMask" type="DaysMaskMap" optional="true" />
+      <arg name="StartHour" type="int8u" optional="true" />
+      <arg name="StartMinute" type="int8u" optional="true" />
+      <arg name="EndHour" type="int8u" optional="true" />
+      <arg name="EndMinute" type="int8u" optional="true" />
+      <mandatoryConform>
+        <feature name="WDSCH"/>
+      </mandatoryConform>
+    </command>
+    <!-- Conformance feature WDSCH - for now optional -->
+    <command source="client" code="13" name="ClearWeekDaySchedule" optional="true">
+      <description>Clear the specific weekly schedule or all weekly schedules for the specific user.</description>
+      <access op="invoke" role="administer"/>
+      <arg name="WeekDayIndex" type="int8u" />
+      <arg name="UserIndex" type="int16u" />
+      <mandatoryConform>
+        <feature name="WDSCH"/>
+      </mandatoryConform>
+    </command>
+    <!-- Conformance feature YDSCH - for now optional -->
+    <command source="client" code="14" name="SetYearDaySchedule" optional="true">
+      <description>Set a time-specific schedule ID for a specified user.</description>
+      <access op="invoke" role="administer"/>
+      <arg name="YearDayIndex" type="int8u" />
+      <arg name="UserIndex" type="int16u" />
+      <arg name="LocalStartTime" type="epoch_s" />
+      <arg name="LocalEndTime" type="epoch_s" />
+      <mandatoryConform>
+        <feature name="YDSCH"/>
+      </mandatoryConform>
+    </command>
+    <!-- Conformance feature YDSCH - for now optional -->
+    <command source="client" code="15" name="GetYearDaySchedule" response="GetYearDayScheduleResponse" optional="true">
+      <description>Returns the year day schedule data for the specified schedule and user indexes.</description>
+      <access op="invoke" role="administer"/>
+      <arg name="YearDayIndex" type="int8u" />
+      <arg name="UserIndex" type="int16u" />
+      <mandatoryConform>
+        <feature name="YDSCH"/>
+      </mandatoryConform>
+    </command>
+    <!-- Conformance feature YDSCH - for now optional -->
+    <command source="server" code="15" name="GetYearDayScheduleResponse" disableDefaultResponse="true" optional="true">
+      <description>Returns the year day schedule data for the specified schedule and user indexes.</description>
+      <arg name="YearDayIndex" type="int8u" />
+      <arg name="UserIndex" type="int16u" />
+      <arg name="Status" type="DlStatus" />
+      <arg name="LocalStartTime" type="epoch_s" optional="true" />
+      <arg name="LocalEndTime" type="epoch_s" optional="true" />
+      <mandatoryConform>
+        <feature name="YDSCH"/>
+      </mandatoryConform>
+    </command>
+    <!-- Conformance feature YDSCH - for now optional -->
+    <command source="client" code="16" name="ClearYearDaySchedule" optional="true">
+      <description>Clears the specific year day schedule or all year day schedules for the specific user.</description>
+      <access op="invoke" role="administer"/>
+      <arg name="YearDayIndex" type="int8u" />
+      <arg name="UserIndex" type="int16u" />
+      <mandatoryConform>
+        <feature name="YDSCH"/>
+      </mandatoryConform>
+    </command>
+    <!-- Conformance feature HDSCH - for now optional -->
+    <command source="client" code="17" name="SetHolidaySchedule" optional="true">
+      <description>Set the holiday Schedule by specifying local start time and local end time with respect to any Lock Operating Mode.</description>
+      <access op="invoke" role="administer"/>
+      <arg name="HolidayIndex" type="int8u" />
+      <arg name="LocalStartTime" type="epoch_s" />
+      <arg name="LocalEndTime" type="epoch_s" />
+      <arg name="OperatingMode" type="OperatingModeEnum" />
+      <mandatoryConform>
+        <feature name="HDSCH"/>
+      </mandatoryConform>
+    </command>
+    <!-- Conformance feature HDSCH - for now optional -->
+    <command source="client" code="18" name="GetHolidaySchedule" response="GetHolidayScheduleResponse" optional="true">
+      <description>Get the holiday schedule for the specified index.</description>
+      <access op="invoke" role="administer"/>
+      <arg name="HolidayIndex" type="int8u" />
+      <mandatoryConform>
+        <feature name="HDSCH"/>
+      </mandatoryConform>
+    </command>
+    <!-- Conformance feature HDSCH - for now optional -->
+    <command source="server" code="18" name="GetHolidayScheduleResponse" disableDefaultResponse="true" optional="true">
+      <description>Returns the Holiday Schedule Entry for the specified Holiday ID.</description>
+      <arg name="HolidayIndex" type="int8u" />
+      <arg name="Status" type="DlStatus" />
+      <arg name="LocalStartTime" type="epoch_s" optional="true" />
+      <arg name="LocalEndTime" type="epoch_s" optional="true" />
+      <arg name="OperatingMode" type="OperatingModeEnum" optional="true" />
+      <mandatoryConform>
+        <feature name="HDSCH"/>
+      </mandatoryConform>
+    </command>
+    <!-- Conformance feature HDSCH - for now optional -->
+    <command source="client" code="19" name="ClearHolidaySchedule" optional="true">
+      <description>Clears the holiday schedule or all holiday schedules.</description>
+      <access op="invoke" role="administer"/>
+      <arg name="HolidayIndex" type="int8u" />
+      <mandatoryConform>
+        <feature name="HDSCH"/>
+      </mandatoryConform>
+    </command>
+    <!-- Conformance feature USR - for now optional -->
+    <command source="client" code="26" name="SetUser" mustUseTimedInvoke="true" optional="true">
+      <description>Set User into the lock.</description>
+      <access op="invoke" role="administer"/>
+      <arg name="OperationType" type="DataOperationTypeEnum" />
+      <arg name="UserIndex" type="int16u" />
+      <arg name="UserName" type="char_string" isNullable="true" />
+      <arg name="UserUniqueID" type="int32u" isNullable="true" />
+      <arg name="UserStatus" type="UserStatusEnum" isNullable="true" />
+      <arg name="UserType" type="UserTypeEnum" isNullable="true" />
+      <arg name="CredentialRule" type="CredentialRuleEnum" isNullable="true" />
+      <mandatoryConform>
+        <feature name="USR"/>
+      </mandatoryConform>
+    </command>
+    <!-- Conformance feature USR - for now optional -->
+    <command source="client" code="27" name="GetUser" response="GetUserResponse" optional="true">
+      <description>Retrieve User.</description>
+      <access op="invoke" role="administer"/>
+      <arg name="UserIndex" type="int16u" />
+      <mandatoryConform>
+        <feature name="USR"/>
+      </mandatoryConform>
+    </command>
+    <!-- Conformance feature USR - for now optional -->
+    <command source="server" code="28" name="GetUserResponse" disableDefaultResponse="true" optional="true">
+      <description>Returns the User for the specified UserIndex.</description>
+      <arg name="UserIndex" type="int16u" />
+      <arg name="UserName" type="char_string" isNullable="true" />
+      <arg name="UserUniqueID" type="int32u" isNullable="true" />
+      <arg name="UserStatus" type="UserStatusEnum" isNullable="true" />
+      <arg name="UserType" type="UserTypeEnum" isNullable="true" />
+      <arg name="CredentialRule" type="CredentialRuleEnum" isNullable="true" />
+      <arg name="Credentials" type="CredentialStruct" array="true" isNullable="true" />
+      <arg name="CreatorFabricIndex" type="fabric_idx" isNullable="true" />
+      <arg name="LastModifiedFabricIndex" type="fabric_idx" isNullable="true" />
+      <arg name="NextUserIndex" type="int16u" isNullable="true" />
+      <mandatoryConform>
+        <feature name="USR"/>
+      </mandatoryConform>
+    </command>
+    <!-- Conformance feature USR - for now optional -->
+    <command source="client" code="29" name="ClearUser" mustUseTimedInvoke="true" optional="true">
+      <description>Clears a User or all Users.</description>
+      <access op="invoke" role="administer"/>
+      <arg name="UserIndex" type="int16u" />
+      <mandatoryConform>
+        <feature name="USR"/>
+      </mandatoryConform>
+    </command>
+    <!-- Conformance feature USR - for now optional -->
+    <command source="client" code="34" name="SetCredential" response="SetCredentialResponse" mustUseTimedInvoke="true" optional="true">
+      <description>Set a credential (e.g. PIN, RFID, Fingerprint, etc.) into the lock for a new user, existing user, or ProgrammingUser.</description>
+      <access op="invoke" role="administer"/>
+      <arg name="OperationType" type="DataOperationTypeEnum" />
+      <arg name="Credential" type="CredentialStruct" />
+      <arg name="CredentialData" type="long_octet_string" />
+      <arg name="UserIndex" type="int16u" isNullable="true" />
+      <arg name="UserStatus" type="UserStatusEnum" isNullable="true" />
+      <arg name="UserType" type="UserTypeEnum" isNullable="true" />
+      <mandatoryConform>
+        <feature name="USR"/>
+      </mandatoryConform>
+    </command>
+    <!-- Conformance feature USR - for now optional -->
+    <command source="server" code="35" name="SetCredentialResponse" disableDefaultResponse="true" optional="true">
+      <description>Returns the status for setting the specified credential.</description>
+      <arg name="Status" type="DlStatus" />
+      <arg name="UserIndex" type="int16u" isNullable="true" />
+      <arg name="NextCredentialIndex" type="int16u" isNullable="true" />
+      <mandatoryConform>
+        <feature name="USR"/>
+      </mandatoryConform>
+    </command>
+    <!-- Conformance feature USR - for now optional -->
+    <command source="client" code="36" name="GetCredentialStatus" response="GetCredentialStatusResponse" optional="true">
+      <description>Retrieve the status of a particular credential (e.g. PIN, RFID, Fingerprint, etc.) by index.</description>
+      <access op="invoke" role="administer"/>
+      <arg name="Credential" type="CredentialStruct" />
+      <mandatoryConform>
+        <feature name="USR"/>
+      </mandatoryConform>
+    </command>
+    <!-- Conformance feature USR - for now optional -->
+    <command source="server" code="37" name="GetCredentialStatusResponse" disableDefaultResponse="true" optional="true">
+      <description>Returns the status for the specified credential.</description>
+      <arg name="CredentialExists" type="boolean" />
+      <arg name="UserIndex" type="int16u" isNullable="true" />
+      <arg name="CreatorFabricIndex" type="fabric_idx" isNullable="true" />
+      <arg name="LastModifiedFabricIndex" type="fabric_idx" isNullable="true" />
+      <arg name="NextCredentialIndex" type="int16u" isNullable="true" />
+      <arg name="CredentialData" type="octet_string" isNullable="true" optional="true" />
+      <mandatoryConform>
+        <feature name="USR"/>
+      </mandatoryConform>
+    </command>
+    <!-- Conformance feature USR - for now optional -->
+    <command source="client" code="38" name="ClearCredential" mustUseTimedInvoke="true" optional="true">
+      <description>Clear one, one type, or all credentials except ProgrammingPIN credential.</description>
+      <access op="invoke" role="administer"/>
+      <arg name="Credential" type="CredentialStruct" isNullable="true" />
+      <mandatoryConform>
+        <feature name="USR"/>
+      </mandatoryConform>
+    </command>
+    <command source="client" code="39" name="UnboltDoor" mustUseTimedInvoke="true" optional="true">
+      <description>This command causes the lock device to unlock the door without pulling the latch.</description>
+      <!-- Conformance feature [COTA & PIN] - for now optional -->
+      <arg name="PINCode" type="octet_string" optional="true" />
+      <mandatoryConform>
+        <feature name="UBOLT"/>
+      </mandatoryConform>
+    </command>
+    <command source="client" code="40" name="SetAliroReaderConfig" mustUseTimedInvoke="true" optional="true" apiMaturity="provisional">
+      <description>This command communicates an Aliro Reader configuration to the lock.</description>
+      <access op="invoke" privilege="administer"/>
+      <arg name="SigningKey" type="octet_string" length="32" />
+      <arg name="VerificationKey" type="octet_string" length="65" />
+      <arg name="GroupIdentifier" type="octet_string" length="16" />
+      <arg name="GroupResolvingKey" type="octet_string" length="16" optional="true" />
+      <mandatoryConform>
+        <feature name="ALIRO"/>
+      </mandatoryConform>
+    </command>
+    <command source="client" code="41" name="ClearAliroReaderConfig" mustUseTimedInvoke="true" optional="true" apiMaturity="provisional">
+      <description>This command clears an existing Aliro Reader configuration for the lock.</description>
+      <access op="invoke" privilege="administer"/>
+      <mandatoryConform>
+        <feature name="ALIRO"/>
+      </mandatoryConform>
+    </command>
 
-        <!-- Attributes -->
-        <attribute side="server" code="0" define="LOCK_STATE" type="DlLockState" min="0" max="3" isNullable="true" reportable="true" writable="false">LockState</attribute>
-        <attribute side="server" code="1" define="LOCK_TYPE" type="DlLockType" min="0" max="11" writable="false">LockType</attribute>
-        <attribute side="server" code="2" define="ACTUATOR_ENABLED" type="boolean" writable="false">ActuatorEnabled</attribute>
-        <!-- Conformance feature DPS - for now optional -->
-        <attribute side="server" code="3" define="DOOR_STATE" type="DoorStateEnum" min="0" max="5" isNullable="true" reportable="true" optional="true">DoorState</attribute>
-        <!-- Conformance feature [DPS] - for now optional -->
-        <attribute side="server" code="4" define="DOOR_OPEN_EVENTS" type="int32u" writable="true" optional="true">
-            <description>DoorOpenEvents</description>
-            <access op="read" role="view" />
-            <access op="write" role="manage" />
-        </attribute>
-        <!-- Conformance feature [DPS] - for now optional -->
-        <attribute side="server" code="5" define="DOOR_CLOSED_EVENTS" type="int32u" writable="true" optional="true">
-            <description>DoorClosedEvents</description>
-            <access op="read" role="view" />
-            <access op="write" role="manage" />
-        </attribute>
-        <!-- Conformance feature [DPS] - for now optional -->
-        <attribute side="server" code="6" define="OPEN_PERIOD" type="int16u" writable="true" optional="true">
-            <description>OpenPeriod</description>
-            <access op="read" role="view" />
-            <access op="write" role="manage" />
-        </attribute>
-        <!-- Conformance feature USR - for now optional -->
-        <attribute side="server" code="17" define="NUM_TOTAL_USERS_SUPPORTED" type="int16u" default="0" writable="false" optional="true">NumberOfTotalUsersSupported</attribute>
-        <!-- Conformance feature PIN - for now optional -->
-        <attribute side="server" code="18" define="NUM_PIN_USERS_SUPPORTED" type="int16u" default="0" writable="false" optional="true">NumberOfPINUsersSupported</attribute>
-        <!-- Conformance feature RFID - for now optional -->
-        <attribute side="server" code="19" define="NUM_RFID_USERS_SUPPORTED" type="int16u" default="0" writable="false" optional="true">NumberOfRFIDUsersSupported</attribute>
-        <!-- Conformance feature WDSCH - for now optional -->
-        <attribute side="server" code="20" define="NUM_WEEKDAY_SCHEDULES_SUPPORTED_PER_USER" type="int8u" default="0" writable="false" optional="true">NumberOfWeekDaySchedulesSupportedPerUser</attribute>
-        <!-- Conformance feature YDSCH - for now optional -->
-        <attribute side="server" code="21" define="NUM_YEARDAY_SCHEDULES_SUPPORTED_PER_USER" type="int8u" default="0" writable="false" optional="true">NumberOfYearDaySchedulesSupportedPerUser</attribute>
-        <!-- Conformance feature HDSCH - for now optional -->
-        <attribute side="server" code="22" define="NUM_HOLIDAY_SCHEDULES_SUPPORTED" type="int8u" default="0" writable="false" optional="true">NumberOfHolidaySchedulesSupported</attribute>
-        <!-- Conformance feature PIN - for now optional -->
-        <attribute side="server" code="23" define="MAX_PIN_LENGTH" type="int8u" writable="false" optional="true">MaxPINCodeLength</attribute>
-        <!-- Conformance feature PIN - for now optional -->
-        <attribute side="server" code="24" define="MIN_PIN_LENGTH" type="int8u" writable="false" optional="true">MinPINCodeLength</attribute>
-        <!-- Conformance feature RID - for now optional -->
-        <attribute side="server" code="25" define="MAX_RFID_CODE_LENGTH" type="int8u" writable="false" optional="true">MaxRFIDCodeLength</attribute>
-        <!-- Conformance feature RID - for now optional -->
-        <attribute side="server" code="26" define="MIN_RFID_CODE_LENGTH" type="int8u" writable="false" optional="true">MinRFIDCodeLength</attribute>
-        <!-- Conformance feature USR - for now optional -->
-        <attribute side="server" code="27" define="CREDENTIAL_RULES_SUPPORT" type="DlCredentialRuleMask" min="0x00" max="0xFF" default="1" writable="false" optional="true">CredentialRulesSupport</attribute>
-        <!-- Conformance feature USR - for now optional  -->
-        <attribute side="server" code="28" define="NUM_CREDENTIALS_SUPPORTED_PER_USER" type="int8u" default="0" writable="false" optional="true">NumberOfCredentialsSupportedPerUser</attribute>
-        <attribute side="server" code="33" define="LANGUAGE" type="char_string" length="3" reportable="true" writable="true" optional="true">
-            <description>Language</description>
-            <access op="read" role="view" />
-            <access op="write" role="manage" />
-        </attribute>
-        <attribute side="server" code="34" define="LED_SETTINGS" type="int8u" min="0" max="2" reportable="true" default="0" writable="true" optional="true">
-            <description>LEDSettings</description>
-            <access op="read" role="view" />
-            <access op="write" role="manage" />
-        </attribute>
-        <attribute side="server" code="35" define="AUTO_RELOCK_TIME" type="int32u" reportable="true" writable="true" optional="true">
-            <description>AutoRelockTime</description>
-            <access op="read" role="view" />
-            <access op="write" role="manage" />
-        </attribute>
-        <attribute side="server" code="36" define="SOUND_VOLUME" type="int8u" min="0" max="3" reportable="true" default="0" writable="true" optional="true">
-            <description>SoundVolume</description>
-            <access op="read" role="view" />
-            <access op="write" role="manage" />
-        </attribute>
-        <attribute side="server" code="37" define="OPERATING_MODE" type="OperatingModeEnum" min="0" max="4" reportable="true" writable="true">
-            <description>OperatingMode</description>
-            <access op="read" role="view" />
-            <access op="write" role="manage" />
-        </attribute>
-        <attribute side="server" code="38" define="SUPPORTED_OPERATING_MODES" type="DlSupportedOperatingModes" min="0x0000" max="0xFFFF" default="0xFFF6" writable="false">SupportedOperatingModes</attribute>
-        <attribute side="server" code="39" define="DEFAULT_CONFIGURATION_REGISTER" type="DlDefaultConfigurationRegister" min="0x0000" max="0xFFFF" reportable="true" default="0" writable="false" optional="true">DefaultConfigurationRegister</attribute>
-        <attribute side="server" code="40" define="ENABLE_LOCAL_PROGRAMMING" type="boolean" reportable="true" default="1" writable="true" optional="true">
-            <description>EnableLocalProgramming</description>
-            <access op="read" role="view" />
-            <access op="write" role="administer" />
-        </attribute>
-        <attribute side="server" code="41" define="ENABLE_ONE_TOUCH_LOCKING" type="boolean" reportable="true" default="0" writable="true" optional="true">
-            <description>EnableOneTouchLocking</description>
-            <access op="read" role="view" />
-            <access op="write" role="manage" />
-        </attribute>
-        <attribute side="server" code="42" define="ENABLE_INSIDE_STATUS_LED" type="boolean" reportable="true" default="0" writable="true" optional="true">
-            <description>EnableInsideStatusLED</description>
-            <access op="read" role="view" />
-            <access op="write" role="manage" />
-        </attribute>
-        <attribute side="server" code="43" define="ENABLE_PRIVACY_MODE_BUTTON" type="boolean" reportable="true" default="0" writable="true" optional="true">
-            <description>EnablePrivacyModeButton</description>
-            <access op="read" role="view" />
-            <access op="write" role="manage" />
-        </attribute>
-        <attribute side="server" code="44" define="LOCAL_PROGRAMMING_FEATURES" type="DlLocalProgrammingFeatures" min="0x0" max="0x0F" reportable="true" default="0" writable="true" optional="true">
-            <description>LocalProgrammingFeatures</description>
-            <access op="read" role="view" />
-            <access op="write" role="administer" />
-        </attribute>
-        <!-- Conformance feature PIN | RID - for now optional -->
-        <attribute side="server" code="48" define="WRONG_CODE_ENTRY_LIMIT" type="int8u" min="1" max="255" reportable="true" writable="true" optional="true">
-            <description>WrongCodeEntryLimit</description>
-            <access op="read" role="view" />
-            <access op="write" role="administer" />
-        </attribute>
-        <!-- Conformance feature PIN | RID - for now optional -->
-        <attribute side="server" code="49" define="USER_CODE_TEMPORARY_DISABLE_TIME" type="int8u" min="1" max="255" reportable="true" writable="true" optional="true">
-            <description>UserCodeTemporaryDisableTime</description>
-            <access op="read" role="view" />
-            <access op="write" role="administer" />
-        </attribute>
-        <!-- Conformance feature [PIN] - for now optional -->
-        <attribute side="server" code="50" define="SEND_PIN_OVER_THE_AIR" type="boolean" reportable="true" default="0" writable="true" optional="true">
-            <description>SendPINOverTheAir</description>
-            <access op="read" role="view" />
-            <access op="write" role="administer" />
-        </attribute>
-        <!-- Conformance feature COTA & PIN - for now optional -->
-        <attribute side="server" code="51" define="REQUIRE_PIN_FOR_REMOTE_OPERATION" type="boolean" reportable="true" default="0" writable="true" optional="true">
-            <description>RequirePINforRemoteOperation</description>
-            <access op="read" role="view" />
-            <access op="write" role="administer" />
-        </attribute>
-        <!-- Attribute SecurityLevel with code 52 is deprecated -->
-        <!-- Conformance feature [USR] - for now optional -->
-        <attribute side="server" code="53" define="EXPIRING_USER_TIMEOUT" type="int16u" min="1" max="2880" reportable="true" writable="true" optional="true">
-            <description>ExpiringUserTimeout</description>
-            <access op="read" role="view" />
-            <access op="write" role="administer" />
-        </attribute>
-        <!-- Conformance feature [ALIRO] - optional -->
-        <attribute side="server" code="128" define="ALIRO_READER_VERIFICATION_KEY" type="octet_string" length="65" writable="false" optional="true" isNullable="true" apiMaturity="provisional">
-            <description>AliroReaderVerificationKey</description>
-            <access op="read" privilege="administer" />
-        </attribute>
-        <!-- Conformance feature [ALIRO] - optional -->
-        <attribute side="server" code="129" define="ALIRO_READER_GROUP_IDENTIFIER" type="octet_string" length="16" writable="false" optional="true" isNullable="true" apiMaturity="provisional">
-            <description>AliroReaderGroupIdentifier</description>
-            <access op="read" privilege="administer" />
-        </attribute>
-        <!-- Conformance feature [ALIRO] - optional -->
-        <attribute side="server" code="130" define="ALIRO_READER_GROUP_SUBIDENTIFIER" type="octet_string" length="16" writable="false" optional="true" apiMaturity="provisional">
-            <description>AliroReaderGroupSubIdentifier</description>
-            <access op="read" privilege="administer" />
-        </attribute>
-        <!-- Conformance feature [ALIRO] - optional -->
-        <attribute side="server" code="131" define="ALIRO_EXPEDITED_TRANSACTION_SUPPORTED_PROTOCOL_VERSIONS" type="array" entryType="octet_string" length="16" writable="false" optional="true" apiMaturity="provisional">
-            <description>AliroExpeditedTransactionSupportedProtocolVersions</description>
-            <access op="read" privilege="administer" />
-        </attribute>
-        <!-- Conformance feature [ALBU] - optional if ALIRO is supported -->
-        <attribute side="server" code="132" define="ALIRO_GROUP_RESOLVING_KEY" type="octet_string" length="16" writable="false" optional="true" isNullable="true" apiMaturity="provisional">
-            <description>AliroGroupResolvingKey</description>
-            <access op="read" privilege="administer" />
-        </attribute>
-        <!-- Conformance feature [ALBU] - optional if ALIRO is supported -->
-        <attribute side="server" code="133" define="ALIRO_SUPPORTED_BLE_UWB_PROTOCOL_VERSIONS" type="array" entryType="octet_string" length="16" writable="false" optional="true" apiMaturity="provisional">
-            <description>AliroSupportedBLEUWBProtocolVersions</description>
-            <access op="read" privilege="administer" />
-        </attribute>
-        <!-- Conformance feature [ALBU] - optional if ALIRO is supported -->
-        <attribute side="server" code="134" define="ALIRO_BLE_ADVERTISING_VERSION" type="int8u" writable="false" optional="true" apiMaturity="provisional">
-            <description>AliroBLEAdvertisingVersion</description>
-            <access op="read" privilege="administer" />
-        </attribute>
-        <!-- Conformance feature [ALIRO] - optional -->
-        <attribute side="server" code="135" define="NUMBER_OF_ALIRO_CREDENTIAL_ISSUER_KEYS_SUPPORTED" type="int16u" writable="false" optional="true" apiMaturity="provisional">NumberOfAliroCredentialIssuerKeysSupported</attribute>
-        <!-- Conformance feature [ALIRO] - optional -->
-        <attribute side="server" code="136" define="NUMBER_OF_ALIRO_ENDPOINT_KEYS_SUPPORTED" type="int16u" writable="false" optional="true" apiMaturity="provisional">NumberOfAliroEndpointKeysSupported</attribute>
 
-        <!-- Commands -->
-        <command source="client" code="0" name="LockDoor" mustUseTimedInvoke="true">
-            <description>This command causes the lock device to lock the door.</description>
-            <!-- Conformance feature [COTA & PIN] - for now optional -->
-            <arg name="PINCode" type="octet_string" optional="true" />
-        </command>
-        <command source="client" code="1" name="UnlockDoor" mustUseTimedInvoke="true">
-            <description>This command causes the lock device to unlock the door.</description>
-            <!-- Conformance feature [COTA & PIN] - for now optional -->
-            <arg name="PINCode" type="octet_string" optional="true" />
-        </command>
-        <!-- Command Toggle with ID 2 is deprecated/disallowed -->
-        <command source="client" code="3" name="UnlockWithTimeout" mustUseTimedInvoke="true" optional="true">
-            <description>This command causes the lock device to unlock the door with a timeout parameter.</description>
-            <arg name="Timeout" type="int16u" />
-            <!-- Conformance feature [COTA & PIN] - for now optional -->
-            <arg name="PINCode" type="octet_string" optional="true" />
-        </command>
-        <!-- Conformance feature WDSCH - for now optional -->
-        <command source="client" code="11" name="SetWeekDaySchedule" optional="true">
-            <description>Set a weekly repeating schedule for a specified user.</description>
-            <access op="invoke" role="administer" />
-            <arg name="WeekDayIndex" type="int8u" />
-            <arg name="UserIndex" type="int16u" />
-            <arg name="DaysMask" type="DaysMaskMap" />
-            <arg name="StartHour" type="int8u" />
-            <arg name="StartMinute" type="int8u" />
-            <arg name="EndHour" type="int8u" />
-            <arg name="EndMinute" type="int8u" />
-        </command>
-        <!-- Conformance feature WDSCH - for now optional -->
-        <command source="client" code="12" name="GetWeekDaySchedule" response="GetWeekDayScheduleResponse" optional="true">
-            <description>Retrieve the specific weekly schedule for the specific user.</description>
-            <access op="invoke" role="administer" />
-            <arg name="WeekDayIndex" type="int8u" />
-            <arg name="UserIndex" type="int16u" />
-        </command>
-        <!-- Conformance feature WDSCH - for now optional -->
-        <command source="server" code="12" name="GetWeekDayScheduleResponse" disableDefaultResponse="true" optional="true">
-            <description>Returns the weekly repeating schedule data for the specified schedule index.</description>
-            <arg name="WeekDayIndex" type="int8u" />
-            <arg name="UserIndex" type="int16u" />
-            <arg name="Status" type="DlStatus" />
-            <arg name="DaysMask" type="DaysMaskMap" optional="true" />
-            <arg name="StartHour" type="int8u" optional="true" />
-            <arg name="StartMinute" type="int8u" optional="true" />
-            <arg name="EndHour" type="int8u" optional="true" />
-            <arg name="EndMinute" type="int8u" optional="true" />
-        </command>
-        <!-- Conformance feature WDSCH - for now optional -->
-        <command source="client" code="13" name="ClearWeekDaySchedule" optional="true">
-            <description>Clear the specific weekly schedule or all weekly schedules for the specific user.</description>
-            <access op="invoke" role="administer" />
-            <arg name="WeekDayIndex" type="int8u" />
-            <arg name="UserIndex" type="int16u" />
-        </command>
-        <!-- Conformance feature YDSCH - for now optional -->
-        <command source="client" code="14" name="SetYearDaySchedule" optional="true">
-            <description>Set a time-specific schedule ID for a specified user.</description>
-            <access op="invoke" role="administer" />
-            <arg name="YearDayIndex" type="int8u" />
-            <arg name="UserIndex" type="int16u" />
-            <arg name="LocalStartTime" type="epoch_s" />
-            <arg name="LocalEndTime" type="epoch_s" />
-        </command>
-        <!-- Conformance feature YDSCH - for now optional -->
-        <command source="client" code="15" name="GetYearDaySchedule" response="GetYearDayScheduleResponse" optional="true">
-            <description>Returns the year day schedule data for the specified schedule and user indexes.</description>
-            <access op="invoke" role="administer" />
-            <arg name="YearDayIndex" type="int8u" />
-            <arg name="UserIndex" type="int16u" />
-        </command>
-        <!-- Conformance feature YDSCH - for now optional -->
-        <command source="server" code="15" name="GetYearDayScheduleResponse" disableDefaultResponse="true" optional="true">
-            <description>Returns the year day schedule data for the specified schedule and user indexes.</description>
-            <arg name="YearDayIndex" type="int8u" />
-            <arg name="UserIndex" type="int16u" />
-            <arg name="Status" type="DlStatus" />
-            <arg name="LocalStartTime" type="epoch_s" optional="true" />
-            <arg name="LocalEndTime" type="epoch_s" optional="true" />
-        </command>
-        <!-- Conformance feature YDSCH - for now optional -->
-        <command source="client" code="16" name="ClearYearDaySchedule" optional="true">
-            <description>Clears the specific year day schedule or all year day schedules for the specific user.</description>
-            <access op="invoke" role="administer" />
-            <arg name="YearDayIndex" type="int8u" />
-            <arg name="UserIndex" type="int16u" />
-        </command>
-        <!-- Conformance feature HDSCH - for now optional -->
-        <command source="client" code="17" name="SetHolidaySchedule" optional="true">
-            <description>Set the holiday Schedule by specifying local start time and local end time with respect to any Lock Operating Mode.</description>
-            <access op="invoke" role="administer" />
-            <arg name="HolidayIndex" type="int8u" />
-            <arg name="LocalStartTime" type="epoch_s" />
-            <arg name="LocalEndTime" type="epoch_s" />
-            <arg name="OperatingMode" type="OperatingModeEnum" />
-        </command>
-        <!-- Conformance feature HDSCH - for now optional -->
-        <command source="client" code="18" name="GetHolidaySchedule" response="GetHolidayScheduleResponse" optional="true">
-            <description>Get the holiday schedule for the specified index.</description>
-            <access op="invoke" role="administer" />
-            <arg name="HolidayIndex" type="int8u" />
-        </command>
-        <!-- Conformance feature HDSCH - for now optional -->
-        <command source="server" code="18" name="GetHolidayScheduleResponse" disableDefaultResponse="true" optional="true">
-            <description>Returns the Holiday Schedule Entry for the specified Holiday ID.</description>
-            <arg name="HolidayIndex" type="int8u" />
-            <arg name="Status" type="DlStatus" />
-            <arg name="LocalStartTime" type="epoch_s" optional="true" />
-            <arg name="LocalEndTime" type="epoch_s" optional="true" />
-            <arg name="OperatingMode" type="OperatingModeEnum" optional="true" />
-        </command>
-        <!-- Conformance feature HDSCH - for now optional -->
-        <command source="client" code="19" name="ClearHolidaySchedule" optional="true">
-            <description>Clears the holiday schedule or all holiday schedules.</description>
-            <access op="invoke" role="administer" />
-            <arg name="HolidayIndex" type="int8u" />
-        </command>
-        <!-- Conformance feature USR - for now optional -->
-        <command source="client" code="26" name="SetUser" mustUseTimedInvoke="true" optional="true">
-            <description>Set User into the lock.</description>
-            <access op="invoke" role="administer" />
-            <arg name="OperationType" type="DataOperationTypeEnum" />
-            <arg name="UserIndex" type="int16u" />
-            <arg name="UserName" type="char_string" isNullable="true" />
-            <arg name="UserUniqueID" type="int32u" isNullable="true" />
-            <arg name="UserStatus" type="UserStatusEnum" isNullable="true" />
-            <arg name="UserType" type="UserTypeEnum" isNullable="true" />
-            <arg name="CredentialRule" type="CredentialRuleEnum" isNullable="true" />
-        </command>
-        <!-- Conformance feature USR - for now optional -->
-        <command source="client" code="27" name="GetUser" response="GetUserResponse" optional="true">
-            <description>Retrieve User.</description>
-            <access op="invoke" role="administer" />
-            <arg name="UserIndex" type="int16u" />
-        </command>
-        <!-- Conformance feature USR - for now optional -->
-        <command source="server" code="28" name="GetUserResponse" disableDefaultResponse="true" optional="true">
-            <description>Returns the User for the specified UserIndex.</description>
-            <arg name="UserIndex" type="int16u" />
-            <arg name="UserName" type="char_string" isNullable="true" />
-            <arg name="UserUniqueID" type="int32u" isNullable="true" />
-            <arg name="UserStatus" type="UserStatusEnum" isNullable="true" />
-            <arg name="UserType" type="UserTypeEnum" isNullable="true" />
-            <arg name="CredentialRule" type="CredentialRuleEnum" isNullable="true" />
-            <arg name="Credentials" type="CredentialStruct" array="true" isNullable="true" />
-            <arg name="CreatorFabricIndex" type="fabric_idx" isNullable="true" />
-            <arg name="LastModifiedFabricIndex" type="fabric_idx" isNullable="true" />
-            <arg name="NextUserIndex" type="int16u" isNullable="true" />
-        </command>
-        <!-- Conformance feature USR - for now optional -->
-        <command source="client" code="29" name="ClearUser" mustUseTimedInvoke="true" optional="true">
-            <description>Clears a User or all Users.</description>
-            <access op="invoke" role="administer" />
-            <arg name="UserIndex" type="int16u" />
-        </command>
-        <!-- Conformance feature USR - for now optional -->
-        <command source="client" code="34" name="SetCredential" response="SetCredentialResponse" mustUseTimedInvoke="true" optional="true">
-            <description>Set a credential (e.g. PIN, RFID, Fingerprint, etc.) into the lock for a new user, existing user, or ProgrammingUser.</description>
-            <access op="invoke" role="administer" />
-            <arg name="OperationType" type="DataOperationTypeEnum" />
-            <arg name="Credential" type="CredentialStruct" />
-            <arg name="CredentialData" type="long_octet_string" />
-            <arg name="UserIndex" type="int16u" isNullable="true" />
-            <arg name="UserStatus" type="UserStatusEnum" isNullable="true" />
-            <arg name="UserType" type="UserTypeEnum" isNullable="true" />
-        </command>
-        <!-- Conformance feature USR - for now optional -->
-        <command source="server" code="35" name="SetCredentialResponse" disableDefaultResponse="true" optional="true">
-            <description>Returns the status for setting the specified credential.</description>
-            <arg name="Status" type="DlStatus" />
-            <arg name="UserIndex" type="int16u" isNullable="true" />
-            <arg name="NextCredentialIndex" type="int16u" isNullable="true" />
-        </command>
-        <!-- Conformance feature USR - for now optional -->
-        <command source="client" code="36" name="GetCredentialStatus" response="GetCredentialStatusResponse" optional="true">
-            <description>Retrieve the status of a particular credential (e.g. PIN, RFID, Fingerprint, etc.) by index.</description>
-            <access op="invoke" role="administer" />
-            <arg name="Credential" type="CredentialStruct" />
-        </command>
-        <!-- Conformance feature USR - for now optional -->
-        <command source="server" code="37" name="GetCredentialStatusResponse" disableDefaultResponse="true" optional="true">
-            <description>Returns the status for the specified credential.</description>
-            <arg name="CredentialExists" type="boolean" />
-            <arg name="UserIndex" type="int16u" isNullable="true" />
-            <arg name="CreatorFabricIndex" type="fabric_idx" isNullable="true" />
-            <arg name="LastModifiedFabricIndex" type="fabric_idx" isNullable="true" />
-            <arg name="NextCredentialIndex" type="int16u" isNullable="true" />
-            <arg name="CredentialData" type="octet_string" isNullable="true" optional="true" />
-        </command>
-        <!-- Conformance feature USR - for now optional -->
-        <command source="client" code="38" name="ClearCredential" mustUseTimedInvoke="true" optional="true">
-            <description>Clear one, one type, or all credentials except ProgrammingPIN credential.</description>
-            <access op="invoke" role="administer" />
-            <arg name="Credential" type="CredentialStruct" isNullable="true"/>
-        </command>
-        <command source="client" code="39" name="UnboltDoor" mustUseTimedInvoke="true" optional="true">
-            <description>This command causes the lock device to unlock the door without pulling the latch.</description>
-            <!-- Conformance feature [COTA & PIN] - for now optional -->
-            <arg name="PINCode" type="octet_string" optional="true" />
-        </command>
-        <command source="client" code="40" name="SetAliroReaderConfig" mustUseTimedInvoke="true" optional="true" apiMaturity="provisional">
-            <description>This command communicates an Aliro Reader configuration to the lock.</description>
-            <access op="invoke" privilege="administer" />
-            <arg name="SigningKey" type="octet_string" length="32" />
-            <arg name="VerificationKey" type="octet_string" length="65" />
-            <arg name="GroupIdentifier" type="octet_string" length="16" />
-            <arg name="GroupResolvingKey" type="octet_string" length="16" optional="true" />
-        </command>
-        <command source="client" code="41" name="ClearAliroReaderConfig" mustUseTimedInvoke="true" optional="true" apiMaturity="provisional">
-            <description>This command clears an existing Aliro Reader configuration for the lock.</description>
-            <access op="invoke" privilege="administer" />
-        </command>
+    <!-- Events -->
+    <event side="server" code="0" name="DoorLockAlarm" priority="critical">
+      <description>The door lock cluster provides several alarms which can be sent when there is a critical state on the door lock.</description>
+      <field id="0" name="AlarmCode" type="AlarmCodeEnum" />
+      <mandatoryConform/>
+    </event>
+    <!-- Conformance feature DPS - for now optional -->
+    <event side="server" code="1" name="DoorStateChange" priority="critical" optional="true">
+      <description>The door lock server sends out a DoorStateChange event when the door lock door state changes.</description>
+      <field id="0" name="DoorState" type="DoorStateEnum" />
+      <mandatoryConform>
+        <feature name="DPS"/>
+      </mandatoryConform>
+    </event>
+    <event side="server" code="2" name="LockOperation" priority="critical">
+      <description>The door lock server sends out a LockOperation event when the event is triggered by the various lock operation sources.</description>
+      <field id="0" name="LockOperationType" type="LockOperationTypeEnum" />
+      <field id="1" name="OperationSource" type="OperationSourceEnum" />
+      <field id="2" name="UserIndex" type="int16u" isNullable="true"/>
+      <field id="3" name="FabricIndex" type="fabric_idx" isNullable="true"/>
+      <field id="4" name="SourceNode" type="node_id" isNullable="true"/>
+      <!-- Conformance feature [USR] - for now optional -->
+      <field id="5" name="Credentials" type="CredentialStruct" array="true" isNullable="true" optional="true" />
+      <mandatoryConform/>
+    </event>
+    <event side="server" code="3" name="LockOperationError" priority="critical">
+      <description>The door lock server sends out a LockOperationError event when a lock operation fails for various reasons.</description>
+      <field id="0" name="LockOperationType" type="LockOperationTypeEnum" />
+      <field id="1" name="OperationSource" type="OperationSourceEnum" />
+      <field id="2" name="OperationError" type="OperationErrorEnum" />
+      <field id="3" name="UserIndex" type="int16u" isNullable="true"/>
+      <field id="4" name="FabricIndex" type="fabric_idx" isNullable="true"/>
+      <field id="5" name="SourceNode" type="node_id" isNullable="true"/>
+      <!-- Conformance feature [USR] - for now optional -->
+      <field id="6" name="Credentials" type="CredentialStruct" array="true" isNullable="true" optional="true" />
+      <mandatoryConform/>
+    </event>
+    <event side="server" code="4" name="LockUserChange" priority="info">
+      <description>The door lock server sends out a LockUserChange event when a lock user, schedule, or credential change has occurred.</description>
+      <field id="0" name="LockDataType" type="LockDataTypeEnum" />
+      <field id="1" name="DataOperationType" type="DataOperationTypeEnum" />
+      <field id="2" name="OperationSource" type="OperationSourceEnum" />
+      <field id="3" name="UserIndex" type="int16u" isNullable="true"/>
+      <field id="4" name="FabricIndex" type="fabric_idx" isNullable="true"/>
+      <field id="5" name="SourceNode" type="node_id" isNullable="true"/>
+      <field id="6" name="DataIndex" type="int16u" isNullable="true"/>
+      <mandatoryConform>
+        <feature name="USR"/>
+      </mandatoryConform>
+    </event>
+  </cluster>
 
 
-        <!-- Events -->
-        <event side="server" code="0" name="DoorLockAlarm" priority="critical">
-            <description>The door lock cluster provides several alarms which can be sent when there is a critical state on the door lock.</description>
-            <field id="0" name="AlarmCode" type="AlarmCodeEnum" />
-        </event>
-        <!-- Conformance feature DPS - for now optional -->
-        <event side="server" code="1" name="DoorStateChange" priority="critical" optional="true">
-            <description>The door lock server sends out a DoorStateChange event when the door lock door state changes.</description>
-            <field id="0" name="DoorState" type="DoorStateEnum" />
-        </event>
-        <event side="server" code="2" name="LockOperation" priority="critical">
-            <description>The door lock server sends out a LockOperation event when the event is triggered by the various lock operation sources.</description>
-            <field id="0" name="LockOperationType" type="LockOperationTypeEnum" />
-            <field id="1" name="OperationSource" type="OperationSourceEnum" />
-            <field id="2" name="UserIndex" type="int16u" isNullable="true" />
-            <field id="3" name="FabricIndex" type="fabric_idx" isNullable="true" />
-            <field id="4" name="SourceNode" type="node_id" isNullable="true" />
-            <!-- Conformance feature [USR] - for now optional -->
-            <field id="5" name="Credentials" type="CredentialStruct" array="true" isNullable="true" optional="true" />
-        </event>
-        <event side="server" code="3" name="LockOperationError" priority="critical">
-            <description>The door lock server sends out a LockOperationError event when a lock operation fails for various reasons.</description>
-            <field id="0" name="LockOperationType" type="LockOperationTypeEnum" />
-            <field id="1" name="OperationSource" type="OperationSourceEnum" />
-            <field id="2" name="OperationError" type="OperationErrorEnum" />
-            <field id="3" name="UserIndex" type="int16u" isNullable="true" />
-            <field id="4" name="FabricIndex" type="fabric_idx" isNullable="true" />
-            <field id="5" name="SourceNode" type="node_id" isNullable="true" />
-            <!-- Conformance feature [USR] - for now optional -->
-            <field id="6" name="Credentials" type="CredentialStruct" array="true" isNullable="true" optional="true" />
-        </event>
-        <event side="server" code="4" name="LockUserChange" priority="info">
-            <description>The door lock server sends out a LockUserChange event when a lock user, schedule, or credential change has occurred.</description>
-            <field id="0" name="LockDataType" type="LockDataTypeEnum" />
-            <field id="1" name="DataOperationType" type="DataOperationTypeEnum" />
-            <field id="2" name="OperationSource" type="OperationSourceEnum" />
-            <field id="3" name="UserIndex" type="int16u" isNullable="true" />
-            <field id="4" name="FabricIndex" type="fabric_idx" isNullable="true" />
-            <field id="5" name="SourceNode" type="node_id" isNullable="true" />
-            <field id="6" name="DataIndex" type="int16u" isNullable="true" />
-        </event>
-    </cluster>
+  <!-- Cluster data types -->
+  <enum name="AlarmCodeEnum" type="enum8">
+    <cluster code="0x0101"/>
+    <item value="0" name="LockJammed"/>
+    <item value="1" name="LockFactoryReset"/>
+    <item value="3" name="LockRadioPowerCycled"/>
+    <item value="4" name="WrongCodeEntryLimit"/>
+    <item value="5" name="FrontEsceutcheonRemoved"/>
+    <item value="6" name="DoorForcedOpen"/>
+    <item value="7" name="DoorAjar"/>
+    <item value="8" name="ForcedUser"/>
+  </enum>
+
+  <enum name="CredentialRuleEnum" type="enum8">
+    <cluster code="0x0101"/>
+    <item value="0" name="Single"/>
+    <item value="1" name="Dual"/>
+    <item value="2" name="Tri"/>
+  </enum>
+
+  <bitmap name="DlCredentialRuleMask" type="bitmap8">
+    <cluster code="0x0101"/>
+    <field mask="0x01" name="Single"/>
+    <field mask="0x02" name="Dual"/>
+    <field mask="0x04" name="Tri"/>
+  </bitmap>
+
+  <struct name="CredentialStruct">
+    <cluster code="0x0101"/>
+    <item name="CredentialType" type="CredentialTypeEnum" />
+    <item name="CredentialIndex" type="int16u" />
+  </struct>
+
+  <enum name="CredentialTypeEnum" type="enum8">
+    <cluster code="0x0101"/>
+    <item value="0" name="ProgrammingPIN"/>
+    <item value="1" name="PIN"/>
+    <item value="2" name="RFID"/>
+    <item value="3" name="Fingerprint"/>
+    <item value="4" name="FingerVein"/>
+    <item value="5" name="Face"/>
+    <item value="6" name="AliroCredentialIssuerKey"/>
+    <item value="7" name="AliroEvictableEndpointKey"/>
+    <item value="8" name="AliroNonEvictableEndpointKey"/>
+  </enum>
+
+  <enum name="DataOperationTypeEnum" type="enum8">
+    <cluster code="0x0101"/>
+    <item value="0" name="Add"/>
+    <item value="1" name="Clear"/>
+    <item value="2" name="Modify"/>
+  </enum>
+
+  <bitmap name="DaysMaskMap" type="bitmap8">
+    <cluster code="0x0101"/>
+    <field mask="0x01" name="Sunday"/>
+    <field mask="0x02" name="Monday"/>
+    <field mask="0x04" name="Tuesday"/>
+    <field mask="0x08" name="Wednesday"/>
+    <field mask="0x10" name="Thursday"/>
+    <field mask="0x20" name="Friday"/>
+    <field mask="0x40" name="Saturday"/>
+  </bitmap>
+
+  <enum name="DoorStateEnum" type="enum8">
+    <cluster code="0x0101"/>
+    <item value="0" name="DoorOpen"/>
+    <item value="1" name="DoorClosed"/>
+    <item value="2" name="DoorJammed"/>
+    <item value="3" name="DoorForcedOpen"/>
+    <item value="4" name="DoorUnspecifiedError"/>
+    <item value="5" name="DoorAjar"/>
+  </enum>
+
+  <enum name="LockDataTypeEnum" type="enum8">
+    <cluster code="0x0101"/>
+    <item value="0" name="Unspecified"/>
+    <item value="1" name="ProgrammingCode"/>
+    <item value="2" name="UserIndex"/>
+    <item value="3" name="WeekDaySchedule"/>
+    <item value="4" name="YearDaySchedule"/>
+    <item value="5" name="HolidaySchedule"/>
+    <item value="6" name="PIN"/>
+    <item value="7" name="RFID"/>
+    <item value="8" name="Fingerprint"/>
+    <item value="9" name="FingerVein"/>
+    <item value="10" name="Face"/>
+    <item value="11" name="AliroCredentialIssuerKey"/>
+    <item value="12" name="AliroEvictableEndpointKey"/>
+    <item value="13" name="AliroNonEvictableEndpointKey"/>
+  </enum>
+
+  <enum name="LockOperationTypeEnum" type="enum8">
+    <cluster code="0x0101"/>
+    <item value="0" name="Lock"/>
+    <item value="1" name="Unlock"/>
+    <item value="2" name="NonAccessUserEvent"/>
+    <item value="3" name="ForcedUserEvent"/>
+    <item value="4" name="Unlatch"/>
+  </enum>
+
+  <enum name="OperationErrorEnum" type="enum8">
+    <cluster code="0x0101"/>
+    <item value="0" name="Unspecified"/>
+    <item value="1" name="InvalidCredential"/>
+    <item value="2" name="DisabledUserDenied"/>
+    <item value="3" name="Restricted"/>
+    <item value="4" name="InsufficientBattery"/>
+  </enum>
+
+  <enum name="OperatingModeEnum" type="enum8">
+    <cluster code="0x0101"/>
+    <item value="0" name="Normal"/>
+    <item value="1" name="Vacation"/>
+    <item value="2" name="Privacy"/>
+    <item value="3" name="NoRemoteLockUnlock"/>
+    <item value="4" name="Passage"/>
+  </enum>
+
+  <enum name="OperationSourceEnum" type="enum8">
+    <cluster code="0x0101"/>
+    <item value="0" name="Unspecified"/>
+    <item value="1" name="Manual"/>
+    <item value="2" name="ProprietaryRemote"/>
+    <item value="3" name="Keypad"/>
+    <item value="4" name="Auto"/>
+    <item value="5" name="Button"/>
+    <item value="6" name="Schedule"/>
+    <item value="7" name="Remote"/>
+    <item value="8" name="RFID"/>
+    <item value="9" name="Biometric"/>
+    <item value="10" name="Aliro"/>
+  </enum>
+
+  <enum name="UserStatusEnum" type="enum8">
+    <cluster code="0x0101"/>
+    <item value="0" name="Available"/>
+    <item value="1" name="OccupiedEnabled"/>
+    <item value="3" name="OccupiedDisabled"/>
+  </enum>
+
+  <enum name="UserTypeEnum" type="enum8">
+    <cluster code="0x0101"/>
+    <item value="0" name="UnrestrictedUser"/>
+    <item value="1" name="YearDayScheduleUser"/>
+    <item value="2" name="WeekDayScheduleUser"/>
+    <item value="3" name="ProgrammingUser"/>
+    <item value="4" name="NonAccessUser"/>
+    <item value="5" name="ForcedUser"/>
+    <item value="6" name="DisposableUser"/>
+    <item value="7" name="ExpiringUser"/>
+    <item value="8" name="ScheduleRestrictedUser"/>
+    <item value="9" name="RemoteOnlyUser"/>
+  </enum>
 
 
-    <!-- Cluster data types -->
-    <enum name="AlarmCodeEnum" type="enum8">
-        <cluster code="0x0101" />
-        <item value="0" name="LockJammed" />
-        <item value="1" name="LockFactoryReset" />
-        <item value="3" name="LockRadioPowerCycled" />
-        <item value="4" name="WrongCodeEntryLimit" />
-        <item value="5" name="FrontEsceutcheonRemoved" />
-        <item value="6" name="DoorForcedOpen" />
-        <item value="7" name="DoorAjar" />
-        <item value="8" name="ForcedUser" />
-    </enum>
+  <!-- Auxiliary data types -->
+  <!-- LockState Attribute Values -->
+  <enum name="DlLockState" type="enum8">
+    <cluster code="0x0101"/>
+    <item value="0" name="NotFullyLocked"/>
+    <item value="1" name="Locked"/>
+    <item value="2" name="Unlocked"/>
+    <item value="3" name="Unlatched"/>
+  </enum>
 
-    <enum name="CredentialRuleEnum" type="enum8">
-        <cluster code="0x0101" />
-        <item value="0" name="Single" />
-        <item value="1" name="Dual" />
-        <item value="2" name="Tri" />
-    </enum>
+  <!-- LockType Attribute Values -->
+  <enum name="DlLockType" type="enum8">
+    <cluster code="0x0101"/>
+    <item value="0" name="Dead bolt" />
+    <item value="1" name="Magnetic"/>
+    <item value="2" name="Other"/>
+    <item value="3" name="Mortise"/>
+    <item value="4" name="Rim"/>
+    <item value="5" name="LatchBolt"/>
+    <item value="6" name="CylindricalLock"/>
+    <item value="7" name="TubularLock"/>
+    <item value="8" name="InterconnectedLock"/>
+    <item value="9" name="DeadLatch"/>
+    <item value="10" name="DoorFurniture"/>
+    <item value="11" name="Eurocylinder"/>
+  </enum>
 
-    <bitmap name="DlCredentialRuleMask" type="bitmap8">
-        <cluster code="0x0101" />
-        <field mask="0x01" name="Single" />
-        <field mask="0x02" name="Dual" />
-        <field mask="0x04" name="Tri" />
-    </bitmap> 
+  <!-- CredentialRulesSupport attribute bit meaning set -->
+  <bitmap name="DlCredentialRulesSupport" type="bitmap8">
+    <cluster code="0x0101" />
+    <field mask="0x01" name="Single" />
+    <field mask="0x02" name="Dual" />
+    <field mask="0x04" name="Tri" />
+  </bitmap>
 
-    <struct name="CredentialStruct">
-        <cluster code="0x0101" />
-        <item name="CredentialType" type="CredentialTypeEnum" />
-        <item name="CredentialIndex" type="int16u" />
-    </struct>
+  <!-- SupportedOperatingModes attribute bit meaning set -->
+  <bitmap name="DlSupportedOperatingModes" type="bitmap16">
+    <cluster code="0x0101"/>
+    <field mask="0x01" name="Normal"/>
+    <field mask="0x02" name="Vacation" /> <!-- Could be optional -->
+    <field mask="0x04" name="Privacy" /> <!-- Could be optional -->
+    <field mask="0x08" name="NoRemoteLockUnlock"/>
+    <field mask="0x10" name="Passage" /> <!-- Could be optional -->
+  </bitmap>
 
-    <enum name="CredentialTypeEnum" type="enum8">
-        <cluster code="0x0101" />
-        <item value="0" name="ProgrammingPIN" />
-        <item value="1" name="PIN" />
-        <item value="2" name="RFID" />
-        <item value="3" name="Fingerprint" />
-        <item value="4" name="FingerVein" />
-        <item value="5" name="Face" />
-        <item value="6" name="AliroCredentialIssuerKey" />
-        <item value="7" name="AliroEvictableEndpointKey" />
-        <item value="8" name="AliroNonEvictableEndpointKey" />
-    </enum>
+  <!-- DefaultConfigurationRegister attribute bit meaning set -->
+  <bitmap name="DlDefaultConfigurationRegister" type="bitmap16">
+    <cluster code="0x0101"/>
+    <field mask="0x01" name="EnableLocalProgrammingEnabled" />
+    <field mask="0x02" name="KeypadInterfaceDefaultAccessEnabled" />
+    <field mask="0x04" name="RemoteInterfaceDefaultAccessIsEnabled" />
+    <field mask="0x20" name="SoundEnabled" />
+    <field mask="0x40" name="AutoRelockTimeSet" />
+    <field mask="0x80" name="LEDSettingsSet" />
+  </bitmap>
 
-    <enum name="DataOperationTypeEnum" type="enum8">
-        <cluster code="0x0101" />
-        <item value="0" name="Add" />
-        <item value="1" name="Clear" />
-        <item value="2" name="Modify" />
-    </enum>
+  <!-- LocalProgrammingFeatures attribute bit meaning set -->
+  <bitmap name="DlLocalProgrammingFeatures" type="bitmap8">
+    <cluster code="0x0101"/>
+    <field mask="0x01" name="AddUsersCredentialsSchedulesLocally" />
+    <field mask="0x02" name="ModifyUsersCredentialsSchedulesLocally" />
+    <field mask="0x04" name="ClearUsersCredentialsSchedulesLocally" />
+    <field mask="0x08" name="AdjustLockSettingsLocally" />
+  </bitmap>
 
-    <bitmap name="DaysMaskMap" type="bitmap8">
-        <cluster code="0x0101" />
-        <field mask="0x01" name="Sunday" />
-        <field mask="0x02" name="Monday" />
-        <field mask="0x04" name="Tuesday" />
-        <field mask="0x08" name="Wednesday" />
-        <field mask="0x10" name="Thursday" />
-        <field mask="0x20" name="Friday" />
-        <field mask="0x40" name="Saturday" />
-    </bitmap>
-
-    <enum name="DoorStateEnum" type="enum8">
-        <cluster code="0x0101" />
-        <item value="0" name="DoorOpen" />
-        <item value="1" name="DoorClosed" />
-        <item value="2" name="DoorJammed" />
-        <item value="3" name="DoorForcedOpen" />
-        <item value="4" name="DoorUnspecifiedError" />
-        <item value="5" name="DoorAjar" />
-    </enum>
-
-    <enum name="LockDataTypeEnum" type="enum8">
-        <cluster code="0x0101" />
-        <item value="0" name="Unspecified" />
-        <item value="1" name="ProgrammingCode" />
-        <item value="2" name="UserIndex" />
-        <item value="3" name="WeekDaySchedule" />
-        <item value="4" name="YearDaySchedule" />
-        <item value="5" name="HolidaySchedule" />
-        <item value="6" name="PIN" />
-        <item value="7" name="RFID" />
-        <item value="8" name="Fingerprint" />
-        <item value="9" name="FingerVein" />
-        <item value="10" name="Face" />
-        <item value="11" name="AliroCredentialIssuerKey" />
-        <item value="12" name="AliroEvictableEndpointKey" />
-        <item value="13" name="AliroNonEvictableEndpointKey" />
-    </enum>
-
-    <enum name="LockOperationTypeEnum" type="enum8">
-        <cluster code="0x0101" />
-        <item value="0" name="Lock" />
-        <item value="1" name="Unlock" />
-        <item value="2" name="NonAccessUserEvent" />
-        <item value="3" name="ForcedUserEvent" />
-        <item value="4" name="Unlatch" />
-    </enum>
-
-    <enum name="OperationErrorEnum" type="enum8">
-        <cluster code="0x0101" />
-        <item value="0" name="Unspecified" />
-        <item value="1" name="InvalidCredential" />
-        <item value="2" name="DisabledUserDenied" />
-        <item value="3" name="Restricted" />
-        <item value="4" name="InsufficientBattery" />
-    </enum>
-
-    <enum name="OperatingModeEnum" type="enum8">
-        <cluster code="0x0101" />
-        <item value="0" name="Normal" />
-        <item value="1" name="Vacation" />
-        <item value="2" name="Privacy" />
-        <item value="3" name="NoRemoteLockUnlock" />
-        <item value="4" name="Passage" />
-    </enum>
-
-    <enum name="OperationSourceEnum" type="enum8">
-        <cluster code="0x0101" />
-        <item value="0" name="Unspecified" />
-        <item value="1" name="Manual" />
-        <item value="2" name="ProprietaryRemote" />
-        <item value="3" name="Keypad" />
-        <item value="4" name="Auto" />
-        <item value="5" name="Button" />
-        <item value="6" name="Schedule" />
-        <item value="7" name="Remote" />
-        <item value="8" name="RFID" />
-        <item value="9" name="Biometric" />
-        <item value="10" name="Aliro" />
-    </enum>
-
-    <enum name="UserStatusEnum" type="enum8">
-        <cluster code="0x0101" />
-        <item value="0" name="Available" />
-        <item value="1" name="OccupiedEnabled" />
-        <item value="3" name="OccupiedDisabled" />
-    </enum>
-
-    <enum name="UserTypeEnum" type="enum8">
-        <cluster code="0x0101" />
-        <item value="0" name="UnrestrictedUser" />
-        <item value="1" name="YearDayScheduleUser" />
-        <item value="2" name="WeekDayScheduleUser" />
-        <item value="3" name="ProgrammingUser" />
-        <item value="4" name="NonAccessUser" />
-        <item value="5" name="ForcedUser" />
-        <item value="6" name="DisposableUser" />
-        <item value="7" name="ExpiringUser" />
-        <item value="8" name="ScheduleRestrictedUser" />
-        <item value="9" name="RemoteOnlyUser" />
-    </enum>
-
-
-    <!-- Auxiliary data types -->
-    <!-- LockState Attribute Values -->
-    <enum name="DlLockState" type="enum8">
-        <cluster code="0x0101" />
-        <item value="0" name="Not Fully Locked" />
-        <item value="1" name="Locked" />
-        <item value="2" name="Unlocked" />
-        <item value="3" name="Unlatched" />
-    </enum>
-
-    <!-- LockType Attribute Values -->
-    <enum name="DlLockType" type="enum8">
-        <cluster code="0x0101" />
-        <item value="0" name="Dead bolt" />
-        <item value="1" name="Magnetic" />
-        <item value="2" name="Other" />
-        <item value="3" name="Mortise" />
-        <item value="4" name="Rim" />
-        <item value="5" name="Latch Bolt" />
-        <item value="6" name="Cylindrical Lock" />
-        <item value="7" name="Tubular Lock" />
-        <item value="8" name="Interconnected Lock" />
-        <item value="9" name="Dead Latch" />
-        <item value="10" name="Door Furniture" />
-        <item value="11" name="Eurocylinder" />
-    </enum>
-
-    <!-- CredentialRulesSupport attribute bit meaning set -->
-    <bitmap name="DlCredentialRulesSupport" type="bitmap8">
-        <cluster code="0x0101" />
-        <field mask="0x01" name="Single" />
-        <field mask="0x02" name="Dual" />
-        <field mask="0x04" name="Tri" />
-    </bitmap>
-
-    <!-- SupportedOperatingModes attribute bit meaning set -->
-    <bitmap name="DlSupportedOperatingModes" type="bitmap16">
-        <cluster code="0x0101" />
-        <field mask="0x01" name="Normal" />
-        <field mask="0x02" name="Vacation" /> <!-- Could be optional -->
-        <field mask="0x04" name="Privacy" /> <!-- Could be optional -->
-        <field mask="0x08" name="NoRemoteLockUnlock" />
-        <field mask="0x10" name="Passage" /> <!-- Could be optional -->
-    </bitmap>
-
-    <!-- DefaultConfigurationRegister attribute bit meaning set -->
-    <bitmap name="DlDefaultConfigurationRegister" type="bitmap16">
-        <cluster code="0x0101" />
-        <field mask="0x01" name="EnableLocalProgrammingEnabled" />
-        <field mask="0x02" name="KeypadInterfaceDefaultAccessEnabled" />
-        <field mask="0x04" name="RemoteInterfaceDefaultAccessIsEnabled" />
-        <field mask="0x20" name="SoundEnabled" />
-        <field mask="0x40" name="AutoRelockTimeSet" />
-        <field mask="0x80" name="LEDSettingsSet" />
-    </bitmap>
-
-    <!-- LocalProgrammingFeatures attribute bit meaning set -->
-    <bitmap name="DlLocalProgrammingFeatures" type="bitmap8">
-        <cluster code="0x0101" />
-        <field mask="0x01" name="AddUsersCredentialsSchedulesLocally" />
-        <field mask="0x02" name="ModifyUsersCredentialsSchedulesLocally" />
-        <field mask="0x04" name="ClearUsersCredentialsSchedulesLocally" />
-        <field mask="0x08" name="AdjustLockSettingsLocally" />
-    </bitmap>
-
-    <!-- KeypadOperationEventMask attribute bit meaning set -->
+  <!-- KeypadOperationEventMask attribute bit meaning set -->
     <bitmap name="DlKeypadOperationEventMask" type="bitmap16">
         <cluster code="0x0101" />
         <field mask="0x01" name="Unknown" />
@@ -796,7 +1038,7 @@ limitations under the License.
         <field mask="0x80" name="NonAccessUserOpEvent" />
     </bitmap>
 
-    <!-- RemoteOperationEventMask attribute bit meaning set -->
+  <!-- RemoteOperationEventMask attribute bit meaning set -->
     <bitmap name="DlRemoteOperationEventMask" type="bitmap16">
         <cluster code="0x0101" />
         <field mask="0x01" name="Unknown" />
@@ -808,7 +1050,7 @@ limitations under the License.
         <field mask="0x40" name="UnlockInvalidSchedule" />
     </bitmap>
 
-    <!-- ManualOperationEventMask attribute bit meaning set -->
+  <!-- ManualOperationEventMask attribute bit meaning set -->
     <bitmap name="DlManualOperationEventMask" type="bitmap16">
         <cluster code="0x0101" />
         <field mask="0x001" name="Unknown" />
@@ -824,7 +1066,7 @@ limitations under the License.
         <field mask="0x400" name="ManualUnlock" />
     </bitmap>
 
-    <!-- RFIDOperationEventMask attribute bit meaning set -->
+  <!-- RFIDOperationEventMask attribute bit meaning set -->
     <bitmap name="DlRFIDOperationEventMask" type="bitmap16">
         <cluster code="0x0101" />
         <field mask="0x01" name="Unknown" />
@@ -836,7 +1078,7 @@ limitations under the License.
         <field mask="0x40" name="UnlockInvalidSchedule" />
     </bitmap>
 
-    <!-- KeypadProgrammingEventMask attribute bit meaning set -->
+  <!-- KeypadProgrammingEventMask attribute bit meaning set -->
     <bitmap name="DlKeypadProgrammingEventMask" type="bitmap16">
         <cluster code="0x0101" />
         <field mask="0x01" name="Unknown" />
@@ -846,7 +1088,7 @@ limitations under the License.
         <field mask="0x10" name="PINChanged" />
     </bitmap>
 
-    <!-- RemoteProgrammingEventMask attribute bit meaning set -->
+  <!-- RemoteProgrammingEventMask attribute bit meaning set -->
      <bitmap name="DlRemoteProgrammingEventMask" type="bitmap16">
          <cluster code="0x0101" />
          <field mask="0x01" name="Unknown" />
@@ -858,7 +1100,7 @@ limitations under the License.
          <field mask="0x40" name="RFIDCodeCleared" />
      </bitmap>
 
-    <!-- RFIDProgrammingEventMask attribute bit meaning set -->
+  <!-- RFIDProgrammingEventMask attribute bit meaning set -->
     <bitmap name="DlRFIDProgrammingEventMask" type="bitmap16">
         <cluster code="0x0101" />
         <field mask="0x01" name="Unknown" />

--- a/src/app/zap-templates/zcl/data-model/chip/drlc-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/drlc-cluster.xml
@@ -199,21 +199,41 @@ limitations under the License.
       </feature>
     </features>
 
-    <attribute side="server" code="0x0000" define="LOAD_CONTROL_PROGRAMS" type="array" entryType="LoadControlProgramStruct" writable="false">LoadControlPrograms</attribute>
-    <attribute side="server" code="0x0001" define="NUMBER_OF_LOAD_CONTROL_PROGRAMS" type="int8u" min="5" writable="false" default="5">NumberOfLoadControlPrograms</attribute>
-    <attribute side="server" code="0x0002" define="LOAD_CONTROL_EVENTS" type="array" entryType="LoadControlEventStruct" writable="false">Events</attribute>
-    <attribute side="server" code="0x0003" define="LOAD_CONTROL_ACTIVE_EVENTS" type="array" entryType="LoadControlEventStruct" writable="false">ActiveEvents</attribute>
-    <attribute side="server" code="0x0004" define="NUMBER_OF_EVENTS_PER_PROGRAM" type="int8u" min="10" writable="false" default="10">NumberOfEventsPerProgram</attribute>
-    <attribute side="server" code="0x0005" define="NUMBER_OF_TRANSITIONS" type="int8u" min="3" writable="false" default="3">NumberOfTransitions</attribute>
-    <attribute side="server" code="0x0006" define="DEFAULT_RANDOM_START" type="int8u" min="0" max="0x3C" default="0x1E" writable="true">
+    <attribute side="server" code="0x0000" define="LOAD_CONTROL_PROGRAMS" type="array" entryType="LoadControlProgramStruct">
+      <description>LoadControlPrograms</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="NUMBER_OF_LOAD_CONTROL_PROGRAMS" type="int8u" min="5" default="5">
+      <description>NumberOfLoadControlPrograms</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="LOAD_CONTROL_EVENTS" type="array" entryType="LoadControlEventStruct">
+      <description>Events</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="LOAD_CONTROL_ACTIVE_EVENTS" type="array" entryType="LoadControlEventStruct">
+      <description>ActiveEvents</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0004" define="NUMBER_OF_EVENTS_PER_PROGRAM" type="int8u" min="10" default="10">
+      <description>NumberOfEventsPerProgram</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0005" define="NUMBER_OF_TRANSITIONS" type="int8u" min="3" default="3">
+      <description>NumberOfTransitions</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0006" define="DEFAULT_RANDOM_START" type="int8u" max="0x3C" default="0x1E" writable="true">
       <description>DefaultRandomStart</description>
       <access op="read" privilege="view"/>
       <access op="write" privilege="manage"/>
+      <mandatoryConform/>
     </attribute>
     <attribute side="server" code="0x0007" define="DEFAULT_RANDOM_DURATION" type="int8u" min="0" max="0x3C" default="0" writable="true">
       <description>DefaultRandomDuration</description>
       <access op="read" privilege="view"/>
       <access op="write" privilege="manage"/>
+      <mandatoryConform/>
     </attribute>
 
     <command source="client" code="0x00" name="RegisterLoadControlProgramRequest" optional="false">
@@ -221,18 +241,21 @@ limitations under the License.
         Upon receipt, this SHALL insert a new LoadControlProgramStruct into LoadControlPrograms, or if the ProgramID matches an existing LoadControlProgramStruct, then the provider SHALL be updated with the provided values.
       </description>
       <arg name="LoadControlProgram" type="LoadControlProgramStruct"/>
+      <mandatoryConform/>
     </command>
     <command source="client" code="0x01" name="UnregisterLoadControlProgramRequest" optional="false">
       <description>
         Upon receipt, this SHALL remove a the LoadControlProgramStruct from LoadControlPrograms with the matching ProgramID.
       </description>
       <arg name="LoadControlProgramID" type="octet_string" length="16"/>
+      <mandatoryConform/>
     </command>
     <command source="client" code="0x02" name="AddLoadControlEventRequest" optional="false">
       <description>
         On receipt of the AddLoadControlEventsRequest command, the server SHALL add a load control event.
       </description>
       <arg name="Event" type="LoadControlEventStruct"/>
+      <mandatoryConform/>
     </command>
     <command source="client" code="0x03" name="RemoveLoadControlEventRequest" optional="false">
       <description>
@@ -240,6 +263,7 @@ limitations under the License.
       </description>
       <arg name="EventID" type="octet_string" length="16"/>
       <arg name="CancelControl" type="CancelControlBitmap"/>
+      <mandatoryConform/>
     </command>
     <command source="client" code="0x04" name="ClearLoadControlEventsRequest" optional="true">
       <!-- Note: Maybe this command needs to have fields?  Who knows!
@@ -265,6 +289,7 @@ limitations under the License.
       <!-- Spec has an invalid field ID that cannot be used, so not enabling the Signature field for now.  See
            https://github.com/CHIP-Specifications/connectedhomeip-spec/issues/8515 -->
       <!-- <field id="0xFF" name="Signature" type="octet_string" length="48" isNullable="true"/> -->
+      <mandatoryConform/>
     </event>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/electrical-energy-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/electrical-energy-measurement-cluster.xml
@@ -42,25 +42,71 @@ limitations under the License.
     </features>
 
     <!--Attributes-->
-    <attribute code="0x0000" side="server" define="ACCURACY" type="MeasurementAccuracyStruct">Accuracy</attribute>
-    <attribute code="0x0001" side="server" define="CUMULATIVE_ENERGY_IMPORTED" type="EnergyMeasurementStruct" optional="true" isNullable="true">CumulativeEnergyImported</attribute>
+    <attribute code="0x0000" side="server" define="ACCURACY" type="MeasurementAccuracyStruct">
+      <description>Accuracy</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute code="0x0001" side="server" define="CUMULATIVE_ENERGY_IMPORTED" type="EnergyMeasurementStruct" optional="true" isNullable="true">
+      <description>CumulativeEnergyImported</description>
+      <mandatoryConform>
+        <andTerm>
+          <feature name="IMPE"/>
+          <feature name="CUME"/>
+        </andTerm>
+      </mandatoryConform>
+    </attribute>
     <!--Conformance feature IMPE & CUME - for now optional-->
-    <attribute code="0x0002" side="server" define="CUMULATIVE_ENERGY_EXPORTED" type="EnergyMeasurementStruct" isNullable="true" optional="true">CumulativeEnergyExported</attribute>
+    <attribute code="0x0002" side="server" define="CUMULATIVE_ENERGY_EXPORTED" type="EnergyMeasurementStruct" isNullable="true" optional="true">
+      <description>CumulativeEnergyExported</description>
+      <mandatoryConform>
+        <andTerm>
+          <feature name="EXPE"/>
+          <feature name="CUME"/>
+        </andTerm>
+      </mandatoryConform>
+    </attribute>
     <!--Conformance feature EXPE & CUME - for now optional-->
-    <attribute code="0x0003" side="server" define="PERIODIC_ENERGY_IMPORTED" type="EnergyMeasurementStruct" isNullable="true" optional="true">PeriodicEnergyImported</attribute>
+    <attribute code="0x0003" side="server" define="PERIODIC_ENERGY_IMPORTED" type="EnergyMeasurementStruct" isNullable="true" optional="true">
+      <description>PeriodicEnergyImported</description>
+      <mandatoryConform>
+        <andTerm>
+          <feature name="IMPE"/>
+          <feature name="PERE"/>
+        </andTerm>
+      </mandatoryConform>
+    </attribute>
     <!--Conformance feature IMPE & PERE - for now optional-->
-    <attribute code="0x0004" side="server" define="PERIODIC_ENERGY_EXPORTED" type="EnergyMeasurementStruct" isNullable="true" optional="true">PeriodicEnergyExported</attribute>
-    <attribute code="0x0005" side="server" define="CUMULATIVE_ENERGY_RESET" type="CumulativeEnergyResetStruct" isNullable="true" optional="true">CumulativeEnergyReset</attribute>
+    <attribute code="0x0004" side="server" define="PERIODIC_ENERGY_EXPORTED" type="EnergyMeasurementStruct" isNullable="true" optional="true">
+      <description>PeriodicEnergyExported</description>
+      <mandatoryConform>
+        <andTerm>
+          <feature name="EXPE"/>
+          <feature name="PERE"/>
+        </andTerm>
+      </mandatoryConform>
+    </attribute>
+    <attribute code="0x0005" side="server" define="CUMULATIVE_ENERGY_RESET" type="CumulativeEnergyResetStruct" isNullable="true" optional="true">
+      <description>CumulativeEnergyReset</description>
+      <optionalConform>
+        <feature name="CUME"/>
+      </optionalConform>
+    </attribute>
     <!--Conformance feature EXPE & PERE - for now optional-->
     <event code="0x00" side="server" name="CumulativeEnergyMeasured" priority="info" optional="true">
       <description>CumulativeEnergyMeasured</description>
       <field id="0" name="EnergyImported" type="EnergyMeasurementStruct" optional="true"/>
       <field id="1" name="EnergyExported" type="EnergyMeasurementStruct" optional="true"/>
+      <mandatoryConform>
+        <feature name="CUME"/>
+      </mandatoryConform>
     </event>
     <event code="0x01" side="server" name="PeriodicEnergyMeasured" priority="info" optional="true">
       <description>PeriodicEnergyMeasured</description>
       <field id="0" name="EnergyImported" type="EnergyMeasurementStruct" optional="true"/>
       <field id="1" name="EnergyExported" type="EnergyMeasurementStruct" optional="true"/>
+      <mandatoryConform>
+        <feature name="PERE"/>
+      </mandatoryConform>
     </event>
   </cluster>
   <struct name="CumulativeEnergyResetStruct">

--- a/src/app/zap-templates/zcl/data-model/chip/electrical-power-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/electrical-power-measurement-cluster.xml
@@ -51,40 +51,124 @@ limitations under the License.
     </features>
 
     <!--Attributes-->
-    <attribute code="0x0000" side="server" define="POWER_MODE" type="PowerModeEnum" min="0x00" max="0x02">PowerMode</attribute>
-    <attribute code="0x0001" side="server" define="NUMBER_OF_MEASUREMENT_TYPES" type="int8u" min="1">NumberOfMeasurementTypes</attribute>
-    <attribute code="0x0002" side="server" define="ACCURACY" type="array" entryType="MeasurementAccuracyStruct" minLength="1">Accuracy</attribute>
-    <attribute code="0x0003" side="server" define="RANGES" type="array" optional="true" entryType="MeasurementRangeStruct" minLength="0">Ranges</attribute>
-    <attribute code="0x0004" side="server" define="VOLTAGE" type="voltage_mv" isNullable="true" min="-4611686018427387904" max="4611686018427387904" optional="true">Voltage</attribute>
+    <attribute code="0x0000" side="server" define="POWER_MODE" type="PowerModeEnum" min="0x00" max="0x02">
+      <description>PowerMode</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute code="0x0001" side="server" define="NUMBER_OF_MEASUREMENT_TYPES" type="int8u" min="1">
+      <description>NumberOfMeasurementTypes</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute code="0x0002" side="server" define="ACCURACY" type="array" entryType="MeasurementAccuracyStruct" minLength="1">
+      <description>Accuracy</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute code="0x0003" side="server" define="RANGES" type="array" optional="true" entryType="MeasurementRangeStruct" minLength="0">
+      <description>Ranges</description>
+      <optionalConform/>
+    </attribute>
+    <attribute code="0x0004" side="server" define="VOLTAGE" type="voltage_mv" isNullable="true" min="-4611686018427387904" max="4611686018427387904" optional="true">
+      <description>Voltage</description>
+      <optionalConform/>
+    </attribute>
     <!--Conformance feature [ALTC] - for now optional-->
-    <attribute code="0x0005" side="server" define="ACTIVE_CURRENT" type="amperage_ma" isNullable="true" min="-4611686018427387904" max="4611686018427387904" optional="true">ActiveCurrent</attribute>
+    <attribute code="0x0005" side="server" define="ACTIVE_CURRENT" type="amperage_ma" isNullable="true" min="-4611686018427387904" max="4611686018427387904" optional="true">
+      <description>ActiveCurrent</description>
+      <optionalConform/>
+    </attribute>
     <!--Conformance feature [ALTC] - for now optional-->
-    <attribute code="0x0006" side="server" define="REACTIVE_CURRENT" type="amperage_ma" isNullable="true" min="-4611686018427387904" max="4611686018427387904" optional="true">ReactiveCurrent</attribute>
-    <attribute code="0x0007" side="server" define="APPARENT_CURRENT" type="amperage_ma" isNullable="true" min="0" max="4611686018427387904" optional="true">ApparentCurrent</attribute>
+    <attribute code="0x0006" side="server" define="REACTIVE_CURRENT" type="amperage_ma" isNullable="true" min="-4611686018427387904" max="4611686018427387904" optional="true">
+      <description>ReactiveCurrent</description>
+      <optionalConform>
+        <feature name="ALTC"/>
+      </optionalConform>
+    </attribute>
+    <attribute code="0x0007" side="server" define="APPARENT_CURRENT" type="amperage_ma" isNullable="true" min="0" max="4611686018427387904" optional="true">
+      <description>ApparentCurrent</description>
+      <optionalConform>
+        <feature name="ALTC"/>
+      </optionalConform>
+    </attribute>
     <!--Conformance feature [ALTC] - for now optional-->
-    <attribute code="0x0008" side="server" define="ACTIVE_POWER" type="power_mw" isNullable="true" min="-4611686018427387904" max="4611686018427387904">ActivePower</attribute>
+    <attribute code="0x0008" side="server" define="ACTIVE_POWER" type="power_mw" isNullable="true" min="-4611686018427387904" max="4611686018427387904">
+      <description>ActivePower</description>
+      <mandatoryConform/>
+    </attribute>
     <!--Conformance feature [ALTC] - for now optional-->
-    <attribute code="0x0009" side="server" define="REACTIVE_POWER" type="power_mw" isNullable="true" min="-4611686018427387904" max="4611686018427387904" optional="true">ReactivePower</attribute>
+    <attribute code="0x0009" side="server" define="REACTIVE_POWER" type="power_mw" isNullable="true" min="-4611686018427387904" max="4611686018427387904" optional="true">
+      <description>ReactivePower</description>
+      <optionalConform>
+        <feature name="ALTC"/>
+      </optionalConform>
+    </attribute>
     <!--Conformance feature [ALTC] - for now optional-->
-    <attribute code="0x000A" side="server" define="APPARENT_POWER" type="power_mw" isNullable="true" min="-4611686018427387904" max="4611686018427387904" optional="true">ApparentPower</attribute>
+    <attribute code="0x000A" side="server" define="APPARENT_POWER" type="power_mw" isNullable="true" min="-4611686018427387904" max="4611686018427387904" optional="true">
+      <description>ApparentPower</description>
+      <optionalConform>
+        <feature name="ALTC"/>
+      </optionalConform>
+    </attribute>
     <!--Conformance feature [ALTC] - for now optional-->
-    <attribute code="0x000B" side="server" define="RMS_VOLTAGE" type="voltage_mv" isNullable="true" min="-4611686018427387904" max="4611686018427387904" optional="true">RMSVoltage</attribute>
+    <attribute code="0x000B" side="server" define="RMS_VOLTAGE" type="voltage_mv" isNullable="true" min="-4611686018427387904" max="4611686018427387904" optional="true">
+      <description>RMSVoltage</description>
+      <optionalConform>
+        <feature name="ALTC"/>
+      </optionalConform>
+    </attribute>
     <!--Conformance feature [ALTC] - for now optional-->
-    <attribute code="0x000C" side="server" define="RMS_CURRENT" type="amperage_ma" isNullable="true" min="-4611686018427387904" max="4611686018427387904" optional="true">RMSCurrent</attribute>
+    <attribute code="0x000C" side="server" define="RMS_CURRENT" type="amperage_ma" isNullable="true" min="-4611686018427387904" max="4611686018427387904" optional="true">
+      <description>RMSCurrent</description>
+      <optionalConform>
+        <feature name="ALTC"/>
+      </optionalConform>
+    </attribute>
     <!--Conformance feature [ALTC] - for now optional-->
-    <attribute code="0x000D" side="server" define="RMS_POWER" type="power_mw" isNullable="true" min="-4611686018427387904" max="4611686018427387904" optional="true">RMSPower</attribute>
+    <attribute code="0x000D" side="server" define="RMS_POWER" type="power_mw" isNullable="true" min="-4611686018427387904" max="4611686018427387904" optional="true">
+      <description>RMSPower</description>
+      <optionalConform>
+        <feature name="ALTC"/>
+      </optionalConform>
+    </attribute>
     <!--Conformance feature HARM - for now optional-->
-    <attribute code="0x000E" side="server" define="FREQUENCY" type="int64s" isNullable="true" optional="true" min="0" max="1000000">Frequency</attribute>
+    <attribute code="0x000E" side="server" define="FREQUENCY" type="int64s" isNullable="true" optional="true" min="0" max="1000000">
+      <description>Frequency</description>
+      <optionalConform>
+        <feature name="ALTC"/>
+      </optionalConform>
+    </attribute>
     <!--Conformance feature PWRQ - for now optional-->
-    <attribute code="0x000F" side="server" define="HARMONIC_CURRENTS" type="array" entryType="HarmonicMeasurementStruct" isNullable="true" optional="true">HarmonicCurrents</attribute>
+    <attribute code="0x000F" side="server" define="HARMONIC_CURRENTS" type="array" entryType="HarmonicMeasurementStruct" isNullable="true" optional="true">
+      <description>HarmonicCurrents</description>
+      <mandatoryConform>
+        <feature name="HARM"/>
+      </mandatoryConform>
+    </attribute>
     <!--Conformance feature [ALTC] - for now optional-->
-    <attribute code="0x0010" side="server" define="HARMONIC_PHASES" type="array" isNullable="true" optional="true" entryType="HarmonicMeasurementStruct">HarmonicPhases</attribute>
+    <attribute code="0x0010" side="server" define="HARMONIC_PHASES" type="array" isNullable="true" optional="true" entryType="HarmonicMeasurementStruct">
+      <description>HarmonicPhases</description>
+      <mandatoryConform>
+        <feature name="PWRQ"/>
+      </mandatoryConform>
+    </attribute>
     <!--Conformance feature [POLY] - for now optional-->
-    <attribute code="0x0011" side="server" define="POWER_FACTOR" type="int64s" isNullable="true" min="-10000" max="10000" optional="true">PowerFactor</attribute>
-    <attribute code="0x0012" side="server" type="amperage_ma" define="NEUTRAL_CURRENT" isNullable="true" min="-4611686018427387904" max="4611686018427387904" optional="true">NeutralCurrent</attribute>
+    <attribute code="0x0011" side="server" define="POWER_FACTOR" type="int64s" isNullable="true" min="-10000" max="10000" optional="true">
+      <description>PowerFactor</description>
+      <optionalConform>
+        <feature name="ALTC"/>
+      </optionalConform>
+    </attribute>
+    <attribute code="0x0012" side="server" type="amperage_ma" define="NEUTRAL_CURRENT" isNullable="true" min="-4611686018427387904" max="4611686018427387904" optional="true">
+      <description>NeutralCurrent</description>
+      <optionalConform>
+        <feature name="POLY"/>
+      </optionalConform>
+    </attribute>
     <event code="0x00" side="server" name="MeasurementPeriodRanges" priority="info" optional="true">
       <description>MeasurementPeriodRanges</description>
       <field id="0" name="Ranges" array="true" type="MeasurementRangeStruct"/>
+      <mandatoryConform>
+        <attribute name="Ranges"/>
+      </mandatoryConform>
     </event>
   </cluster>
   <enum name="PowerModeEnum" type="enum8">

--- a/src/app/zap-templates/zcl/data-model/chip/energy-evse-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/energy-evse-cluster.xml
@@ -128,53 +128,139 @@ Git: 1.4-prerelease-ipr-69-ge15ff5700
       </feature>
     </features>
     <!--Attributes-->
-    <attribute code="0x0000" side="server" type="StateEnum" define="STATE" isNullable="true" min="0x00" max="0x06">State</attribute>
-    <attribute code="0x0001" side="server" type="SupplyStateEnum" define="SUPPLY_STATE" min="0x00" max="0x05">SupplyState</attribute>
-    <attribute code="0x0002" side="server" type="FaultStateEnum" define="FAULT_STATE" min="0x00" max="0xFF">FaultState</attribute>
-    <attribute code="0x0003" side="server" type="epoch_s" define="CHARGING_ENABLED_UNTIL" isNullable="true" default="0">ChargingEnabledUntil</attribute>
+    <attribute code="0x0000" side="server" type="StateEnum" define="STATE" isNullable="true" min="0x00" max="0x06">
+      <description>State</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute code="0x0001" side="server" type="SupplyStateEnum" define="SUPPLY_STATE" min="0x00" max="0x05">
+      <description>SupplyState</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute code="0x0002" side="server" type="FaultStateEnum" define="FAULT_STATE" min="0x00" max="0xFF">
+      <description>FaultState</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute code="0x0003" side="server" type="epoch_s" define="CHARGING_ENABLED_UNTIL" isNullable="true" default="0">
+      <description>ChargingEnabledUntil</description>
+      <mandatoryConform/>
+    </attribute>
     <!--Conformance feature V2X - for now optional-->
-    <attribute code="0x0004" side="server" type="epoch_s" define="DISCHARGING_ENABLED_UNTIL" isNullable="true" default="0" optional="true">DischargingEnabledUntil</attribute>
-    <attribute code="0x0005" side="server" type="amperage_ma" define="CIRCUIT_CAPACITY" default="0" min="0">CircuitCapacity</attribute>
-    <attribute code="0x0006" side="server" type="amperage_ma" define="MINIMUM_CHARGE_CURRENT" default="6000" min="0">MinimumChargeCurrent</attribute>
-    <attribute code="0x0007" side="server" type="amperage_ma" define="MAXIMUM_CHARGE_CURRENT" default="0" min="0">MaximumChargeCurrent</attribute>
+    <attribute code="0x0004" side="server" type="epoch_s" define="DISCHARGING_ENABLED_UNTIL" isNullable="true" default="0" optional="true">
+      <description>DischargingEnabledUntil</description>
+      <mandatoryConform>
+        <feature name="V2X"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute code="0x0005" side="server" type="amperage_ma" define="CIRCUIT_CAPACITY" default="0" min="0">
+      <description>CircuitCapacity</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute code="0x0006" side="server" type="amperage_ma" define="MINIMUM_CHARGE_CURRENT" default="6000" min="0">
+      <description>MinimumChargeCurrent</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute code="0x0007" side="server" type="amperage_ma" define="MAXIMUM_CHARGE_CURRENT" default="0" min="0">
+      <description>MaximumChargeCurrent</description>
+      <mandatoryConform/>
+    </attribute>
     <!--Conformance feature V2X - for now optional-->
-    <attribute code="0x0008" side="server" type="amperage_ma" define="MAXIMUM_DISCHARGE_CURRENT" default="0" min="0" optional="true">MaximumDischargeCurrent</attribute>
+    <attribute code="0x0008" side="server" type="amperage_ma" define="MAXIMUM_DISCHARGE_CURRENT" default="0" min="0" optional="true">
+      <description>MaximumDischargeCurrent</description>
+      <mandatoryConform>
+        <feature name="V2X"/>
+      </mandatoryConform>
+    </attribute>
     <attribute code="0x0009" side="server" type="amperage_ma" define="USER_MAXIMUM_CHARGE_CURRENT" default="0" writable="true" optional="true">
       <access op="write" privilege="manage"/>
       <description>UserMaximumChargeCurrent</description>
+      <optionalConform/>
     </attribute>
     <attribute code="0x000A" side="server" type="elapsed_s" define="RANDOMIZATION_DELAY_WINDOW" default="600" writable="true" optional="true">
       <access op="write" privilege="manage"/>
       <description>RandomizationDelayWindow</description>
+      <optionalConform/>
     </attribute>
     <!--Conformance feature PREF - for now optional-->
     <!--Conformance feature PREF - for now optional-->
     <!--Conformance feature PREF - for now optional-->
-    <attribute code="0x0023" side="server" type="epoch_s" define="NEXT_CHARGE_START_TIME" isNullable="true" optional="true">NextChargeStartTime</attribute>
+    <attribute code="0x0023" side="server" type="epoch_s" define="NEXT_CHARGE_START_TIME" isNullable="true" optional="true">
+      <description>NextChargeStartTime</description>
+      <mandatoryConform>
+        <feature name="PREF"/>
+      </mandatoryConform>
+    </attribute>
     <!--Conformance feature PREF - for now optional-->
-    <attribute code="0x0024" side="server" type="epoch_s" define="NEXT_CHARGE_TARGET_TIME" isNullable="true" optional="true">NextChargeTargetTime</attribute>
+    <attribute code="0x0024" side="server" type="epoch_s" define="NEXT_CHARGE_TARGET_TIME" isNullable="true" optional="true">
+      <description>NextChargeTargetTime</description>
+      <mandatoryConform>
+        <feature name="PREF"/>
+      </mandatoryConform>
+    </attribute>
     <!--Conformance feature PREF - for now optional-->
-    <attribute code="0x0025" side="server" type="energy_mwh" define="NEXT_CHARGE_REQUIRED_ENERGY" isNullable="true" min="0" optional="true">NextChargeRequiredEnergy</attribute>
+    <attribute code="0x0025" side="server" type="energy_mwh" define="NEXT_CHARGE_REQUIRED_ENERGY" isNullable="true" min="0" optional="true">
+      <description>NextChargeRequiredEnergy</description>
+      <mandatoryConform>
+        <feature name="PREF"/>
+      </mandatoryConform>
+    </attribute>
     <!--Conformance feature PREF - for now optional-->
-    <attribute code="0x0026" side="server" type="percent" define="NEXT_CHARGE_TARGET_SOC" isNullable="true" optional="true">NextChargeTargetSoC</attribute>
+    <attribute code="0x0026" side="server" type="percent" define="NEXT_CHARGE_TARGET_SOC" isNullable="true" optional="true">
+      <description>NextChargeTargetSoC</description>
+      <mandatoryConform>
+        <feature name="PREF"/>
+      </mandatoryConform>
+    </attribute>
     <!--Conformance feature [PREF] - for now optional-->
     <attribute code="0x0027" side="server" type="int16u" define="APPROXIMATE_EV_EFFICIENCY" isNullable="true" writable="true" optional="true" max="0xFFFE" min="0">
       <access op="write" privilege="manage"/>
       <description>ApproximateEVEfficiency</description>
+      <optionalConform>
+        <feature name="PREF"/>
+      </optionalConform>
     </attribute>
     <!--Conformance feature SOC - for now optional-->
-    <attribute code="0x0030" side="server" type="percent" define="STATE_OF_CHARGE" isNullable="true" optional="true">StateOfCharge</attribute>
+    <attribute code="0x0030" side="server" type="percent" define="STATE_OF_CHARGE" isNullable="true" optional="true">
+      <description>StateOfCharge</description>
+      <mandatoryConform>
+        <feature name="SOC"/>
+      </mandatoryConform>
+    </attribute>
     <!--Conformance feature SOC - for now optional-->
-    <attribute code="0x0031" side="server" type="energy_mwh" define="BATTERY_CAPACITY" isNullable="true" min="0" optional="true">BatteryCapacity</attribute>
+    <attribute code="0x0031" side="server" type="energy_mwh" define="BATTERY_CAPACITY" isNullable="true" min="0" optional="true">
+      <description>BatteryCapacity</description>
+      <mandatoryConform>
+        <feature name="SOC"/>
+      </mandatoryConform>
+    </attribute>
     <!--Conformance feature PNC - for now optional-->
-    <attribute code="0x0032" side="server" type="char_string" define="VEHICLE_ID" isNullable="true" length="32" optional="true">VehicleID</attribute>
-    <attribute code="0x0040" side="server" type="int32u" define="SESSION_ID" isNullable="true">SessionID</attribute>
-    <attribute code="0x0041" side="server" type="elapsed_s" define="SESSION_DURATION" isNullable="true">SessionDuration</attribute>
-    <attribute code="0x0042" side="server" type="energy_mwh" define="SESSION_ENERGY_CHARGED" isNullable="true" min="0">SessionEnergyCharged</attribute>
+    <attribute code="0x0032" side="server" type="char_string" define="VEHICLE_ID" isNullable="true" length="32" optional="true">
+      <description>VehicleID</description>
+      <mandatoryConform>
+        <feature name="PNC"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute code="0x0040" side="server" type="int32u" define="SESSION_ID" isNullable="true">
+      <description>SessionID</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute code="0x0041" side="server" type="elapsed_s" define="SESSION_DURATION" isNullable="true">
+      <description>SessionDuration</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute code="0x0042" side="server" type="energy_mwh" define="SESSION_ENERGY_CHARGED" isNullable="true" min="0">
+      <description>SessionEnergyCharged</description>
+      <mandatoryConform/>
+    </attribute>
     <!--Conformance feature V2X - for now optional-->
-    <attribute code="0x0043" side="server" type="energy_mwh" define="SESSION_ENERGY_DISCHARGED" isNullable="true" min="0" optional="true">SessionEnergyDischarged</attribute>
+    <attribute code="0x0043" side="server" type="energy_mwh" define="SESSION_ENERGY_DISCHARGED" isNullable="true" min="0" optional="true">
+      <description>SessionEnergyDischarged</description>
+      <mandatoryConform>
+        <feature name="V2X"/>
+      </mandatoryConform>
+    </attribute>
     <command source="client" code="0x01" name="Disable" optional="false" mustUseTimedInvoke="true" apiMaturity="provisional">
       <description>Allows a client to disable the EVSE from charging and discharging.</description>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x02" name="EnableCharging" optional="false" mustUseTimedInvoke="true">
@@ -182,39 +268,57 @@ Git: 1.4-prerelease-ipr-69-ge15ff5700
       <arg id="1" name="MinimumChargeCurrent" type="amperage_ma" min="0"/>
       <arg id="2" name="MaximumChargeCurrent" type="amperage_ma" min="0"/>
       <description>This command allows a client to enable the EVSE to charge an EV, and to provide or update the maximum and minimum charge current.</description>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x03" name="EnableDischarging" optional="true" mustUseTimedInvoke="true" apiMaturity="provisional">
       <arg id="0" name="DischargingEnabledUntil" type="epoch_s" isNullable="true"/>
       <arg id="1" name="MaximumDischargeCurrent" type="amperage_ma" min="0"/>
       <description>Upon receipt, this SHALL allow a client to enable the discharge of an EV, and to provide or update the maximum discharge current.</description>
+      <mandatoryConform>
+        <feature name="V2X"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x04" name="StartDiagnostics" optional="true" mustUseTimedInvoke="true">
       <description>Allows a client to put the EVSE into a self-diagnostics mode.</description>
+      <optionalConform/>
     </command>
 
     <command source="client" code="0x05" name="SetTargets" optional="true" mustUseTimedInvoke="true" apiMaturity="provisional">
       <arg id="0" name="ChargingTargetSchedules" type="ChargingTargetScheduleStruct" array="true" length="7"/>
       <description>Allows a client to set the user specified charging targets.</description>
+      <mandatoryConform>
+        <feature name="PREF"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x06" name="GetTargets" optional="true" response="GetTargetsResponse" mustUseTimedInvoke="true" apiMaturity="provisional">
       <description>Allows a client to retrieve the current set of charging targets.</description>
+      <mandatoryConform>
+        <feature name="PREF"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x07" name="ClearTargets" optional="true" mustUseTimedInvoke="true" apiMaturity="provisional">
       <description>Allows a client to clear all stored charging targets.</description>
+      <mandatoryConform>
+        <feature name="PREF"/>
+      </mandatoryConform>
     </command>
 
     <command source="server" code="0x00" name="GetTargetsResponse" optional="true" apiMaturity="provisional" disableDefaultResponse="true">
       <arg id="0" name="ChargingTargetSchedules" type="ChargingTargetScheduleStruct" array="true" length="7"/>
       <description>The GetTargetsResponse is sent in response to the GetTargets Command.</description>
+      <mandatoryConform>
+        <feature name="PREF"/>
+      </mandatoryConform>
     </command>
 
     <event side="server" code="0x00" name="EVConnected" priority="info">
       <description>This event SHALL be generated when the EV is plugged in.</description>
       <field id="0" name="SessionID" type="int32u"/>
+      <mandatoryConform/>
     </event>
 
     <event side="server" code="0x01" name="EVNotDetected" priority="info">
@@ -224,6 +328,7 @@ Git: 1.4-prerelease-ipr-69-ge15ff5700
       <field id="2" name="SessionDuration" type="elapsed_s"/>
       <field id="3" name="SessionEnergyCharged" type="energy_mwh" min="0"/>
       <field id="4" name="SessionEnergyDischarged" type="energy_mwh" min="0" optional="true" apiMaturity="provisional"/>
+      <mandatoryConform/>
     </event>
 
     <event side="server" code="0x02" name="EnergyTransferStarted" priority="info">
@@ -232,6 +337,7 @@ Git: 1.4-prerelease-ipr-69-ge15ff5700
       <field id="1" name="State" type="StateEnum" min="0x00" max="0x06"/>
       <field id="2" name="MaximumCurrent" type="amperage_ma" min="0"/>
       <field id="3" name="MaximumDischargeCurrent" type="amperage_ma" optional="true" min="0"/>
+      <mandatoryConform/>
     </event>
 
     <event side="server" code="0x03" name="EnergyTransferStopped" priority="info">
@@ -241,6 +347,7 @@ Git: 1.4-prerelease-ipr-69-ge15ff5700
       <field id="2" name="Reason" type="EnergyTransferStoppedReasonEnum" min="0x00" max="0x02"/>
       <field id="4" name="EnergyTransferred" type="energy_mwh" min="0"/>
       <field id="5" name="EnergyDischarged" type="energy_mwh" optional="true" min="0"/>
+      <mandatoryConform/>
     </event>
 
     <event side="server" code="0x04" name="Fault" priority="critical">
@@ -249,11 +356,15 @@ Git: 1.4-prerelease-ipr-69-ge15ff5700
       <field id="1" name="State" type="StateEnum" min="0x00" max="0x06"/>
       <field id="2" name="FaultStatePreviousState" type="FaultStateEnum" min="0x00" max="0xFF"/>
       <field id="4" name="FaultStateCurrentState" type="FaultStateEnum" min="0x00" max="0xFF"/>
+      <mandatoryConform/>
     </event>
 
     <event side="server" code="0x05" name="RFID" priority="info" optional="true">
       <description>This event SHALL be generated when a RFID card has been read.</description>
       <field id="0" name="UID" type="octet_string" length="10"/>
+      <optionalConform>
+        <feature name="RFID"/>
+      </optionalConform>
     </event>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/energy-evse-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/energy-evse-mode-cluster.xml
@@ -59,18 +59,26 @@ Git: 1.4-prerelease-ipr-69-ge15ff5700
       </feature>
     </features>
     <!-- Base data types -->
-    <attribute side="server" code="0x0000" define="SUPPORTED_MODES" type="array" entryType="ModeOptionStruct" length="255" minLength="2">SupportedModes</attribute>
-    <attribute side="server" code="0x0001" define="CURRENT_MODE" type="int8u">CurrentMode</attribute>
+    <attribute side="server" code="0x0000" define="SUPPORTED_MODES" type="array" entryType="ModeOptionStruct" length="255" minLength="2">
+      <description>SupportedModes</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="CURRENT_MODE" type="int8u">
+      <description>CurrentMode</description>
+      <mandatoryConform/>
+    </attribute>
     <!-- Commands -->
     <command source="client" code="0x00" name="ChangeToMode" response="ChangeToModeResponse" optional="false">
       <description>This command is used to change device modes.</description>
       <arg id="0" name="NewMode" type="int8u"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x01" name="ChangeToModeResponse" disableDefaultResponse="true" optional="false">
       <description>This command is sent by the device on receipt of the ChangeToMode command.</description>
       <arg id="0" name="Status" type="enum8"/>
       <arg id="1" name="StatusText" type="char_string" length="64" optional="true"/>
+      <mandatoryConform/>
     </command>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/energy-preference-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/energy-preference-cluster.xml
@@ -34,26 +34,47 @@ limitations under the License.
     </features>
 
     <!--Conformance feature BALA - for now optional-->
-    <attribute code="0x0000" side="server" type="array" entryType="BalanceStruct" define="ENERGY_PREFERENCE_ENERGY_BALANCES" isNullable="false" min="2" max="10" writable="false" optional="true">EnergyBalances</attribute>
-
+    <attribute code="0x0000" side="server" type="array" entryType="BalanceStruct" define="ENERGY_PREFERENCE_ENERGY_BALANCES" min="2" max="10" optional="true">
+      <description>EnergyBalances</description>
+      <mandatoryConform>
+        <feature name="BALA"/>
+      </mandatoryConform>
+    </attribute>
+    
     <!--Conformance feature BALA - for now optional-->
-    <attribute code="0x0001" side="server" type="int8u" define="ENERGY_PREFERENCE_CURRENT_ENERGY_BALANCE" isNullable="false" writable="true" optional="true">
+    <attribute code="0x0001" side="server" type="int8u" define="ENERGY_PREFERENCE_CURRENT_ENERGY_BALANCE" writable="true" optional="true">
+      <description>CurrentEnergyBalance</description>
       <access op="read" privilege="view"/>
       <access op="write" privilege="operate"/>
-      <description>CurrentEnergyBalance</description>
+      <mandatoryConform>
+        <feature name="BALA"/>
+      </mandatoryConform>
     </attribute>
 
     <!--Conformance feature BALA - for now optional-->
-    <attribute code="0x0002" side="server" type="array" entryType="EnergyPriorityEnum" define="ENERGY_PREFERENCE_ENERGY_PRIORITIES" isNullable="false" max="2" writable="false" optional="true">EnergyPriorities</attribute>
+    <attribute code="0x0002" side="server" type="array" entryType="EnergyPriorityEnum" define="ENERGY_PREFERENCE_ENERGY_PRIORITIES" max="2" optional="true">
+      <description>EnergyPriorities</description>
+      <mandatoryConform>
+        <feature name="BALA"/>
+      </mandatoryConform>
+    </attribute>
 
     <!--Conformance feature LPMS - for now optional-->
-    <attribute code="0x0003" side="server" type="array" entryType="BalanceStruct" define="ENERGY_PREFERENCE_LOW_POWER_MODE_SENSITIVITIES" isNullable="false" min="2" max="10" writable="false" optional="true">LowPowerModeSensitivities</attribute>
+    <attribute code="0x0003" side="server" type="array" entryType="BalanceStruct" define="ENERGY_PREFERENCE_LOW_POWER_MODE_SENSITIVITIES" min="2" max="10" optional="true">
+      <description>LowPowerModeSensitivities</description>
+      <mandatoryConform>
+        <feature name="LPMS"/>
+      </mandatoryConform>
+    </attribute>
 
     <!--Conformance feature LPMS - for now optional-->
-    <attribute code="0x0004" side="server" type="int8u" define="ENERGY_PREFERENCE_CURRENT_LOW_POWER_MODE_SENSITIVITY" isNullable="false" writable="true" optional="true">
+    <attribute code="0x0004" side="server" type="int8u" define="ENERGY_PREFERENCE_CURRENT_LOW_POWER_MODE_SENSITIVITY" writable="true" optional="true">
       <access op="read" privilege="view"/>
       <access op="write" privilege="operate"/>
       <description>CurrentLowPowerModeSensitivity</description>
+      <mandatoryConform>
+        <feature name="LPMS"/>
+      </mandatoryConform>
     </attribute>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/ethernet-network-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/ethernet-network-diagnostics-cluster.xml
@@ -37,26 +37,69 @@ limitations under the License.
     <description>The Ethernet Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to assist a user or Administrative Node in diagnosing potential problems.</description>
 
     <features>
-    <feature bit="0" code="PKTCNT" name="PacketCounts" summary="Node makes available the counts for the number of received and transmitted packets on the ethernet interface.">
+      <feature bit="0" code="PKTCNT" name="PacketCounts" summary="Node makes available the counts for the number of received and transmitted packets on the ethernet interface.">
+        <optionalConform/>
+      </feature>
+      <feature bit="1" code="ERRCNT" name="ErrorCounts" summary="Node makes available the counts for the number of errors that have occurred during the reception and transmission of packets on the ethernet interface.">
+        <optionalConform/>
+      </feature>
+    </features>
+    
+    <attribute side="server" code="0x00" define="PHY_RATE" type="PHYRateEnum" isNullable="true" optional="true">
+      <description>PHYRate</description>
       <optionalConform/>
-    </feature>
-    <feature bit="1" code="ERRCNT" name="ErrorCounts" summary="Node makes available the counts for the number of errors that have occurred during the reception and transmission of packets on the ethernet interface.">
+    </attribute>
+    <attribute side="server" code="0x01" define="FULL_DUPLEX" type="boolean" min="0x00" max="0x01" isNullable="true" optional="true">
+      <description>FullDuplex</description>
       <optionalConform/>
-    </feature>
-  </features>
-  
-    <attribute side="server" code="0x00" define="PHY_RATE" type="PHYRateEnum" writable="false" isNullable="true" optional="true">PHYRate</attribute>
-    <attribute side="server" code="0x01" define="FULL_DUPLEX" type="boolean" min="0x00" max="0x01" writable="false" isNullable="true" optional="true">FullDuplex</attribute>
-    <attribute side="server" code="0x02" define="PACKET_RX_COUNT" type="int64u" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="true">PacketRxCount</attribute>
-    <attribute side="server" code="0x03" define="PACKET_TX_COUNT" type="int64u" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="true">PacketTxCount</attribute>
-    <attribute side="server" code="0x04" define="TX_ERR_COUNT" type="int64u" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="true">TxErrCount</attribute>
-    <attribute side="server" code="0x05" define="COLLISION_COUNT" type="int64u" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="true">CollisionCount</attribute>
-    <attribute side="server" code="0x06" define="ETHERNET_OVERRUN_COUNT" type="int64u" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="true">OverrunCount</attribute>
-    <attribute side="server" code="0x07" define="CARRIER_DETECT" type="boolean" min="0x00" max="0x01" writable="false" isNullable="true" optional="true">CarrierDetect</attribute>
-    <attribute side="server" code="0x08" define="TIME_SINCE_RESET" type="int64u" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="true">TimeSinceReset</attribute>
+    </attribute>
+    <attribute side="server" code="0x02" define="PACKET_RX_COUNT" type="int64u" default="0x0000000000000000" optional="true">
+      <description>PacketRxCount</description>
+      <mandatoryConform>
+        <feature name="PKTCNT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x03" define="PACKET_TX_COUNT" type="int64u" default="0x0000000000000000" optional="true">
+      <description>PacketTxCount</description>
+      <mandatoryConform>
+        <feature name="PKTCNT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x04" define="TX_ERR_COUNT" type="int64u" default="0x0000000000000000" optional="true">
+      <description>TxErrCount</description>
+      <mandatoryConform>
+        <feature name="ERRCNT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x05" define="COLLISION_COUNT" type="int64u" default="0x0000000000000000" optional="true">
+      <description>CollisionCount</description>
+      <mandatoryConform>
+        <feature name="ERRCNT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x06" define="ETHERNET_OVERRUN_COUNT" type="int64u" default="0x0000000000000000" optional="true">
+      <description>OverrunCount</description>
+      <mandatoryConform>
+        <feature name="ERRCNT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x07" define="CARRIER_DETECT" type="boolean" min="0x00" max="0x01" isNullable="true" optional="true">
+      <description>CarrierDetect</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x08" define="TIME_SINCE_RESET" type="int64u" default="0x0000000000000000" optional="true">
+      <description>TimeSinceReset</description>
+      <optionalConform/>
+    </attribute>
     <command source="client" code="0x00" name="ResetCounts" optional="true" cli="chip ethernet_network_diagnostics resetcounts">
       <description>Reception of this command SHALL reset the attributes: PacketRxCount, PacketTxCount, TxErrCount, CollisionCount, OverrunCount to 0</description>
       <access op="invoke" role="manage"/>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="PKTCNT"/>
+          <feature name="ERRCNT"/>
+        </orTerm>
+      </mandatoryConform>
     </command>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/fixed-label-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/fixed-label-cluster.xml
@@ -31,6 +31,9 @@ limitations under the License.
     <define>FIXED_LABEL_CLUSTER</define>
     <description>The Fixed Label Cluster provides a feature for the device to tag an endpoint with zero or more read only
 labels.</description>
-    <attribute side="server" code="0x0000" define="LABEL_LIST" type="array" entryType="LabelStruct" writable="false" optional="false">LabelList</attribute>
+    <attribute side="server" code="0x0000" define="LABEL_LIST" type="array" entryType="LabelStruct">
+      <description>LabelList</description>
+      <mandatoryConform/>
+    </attribute>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/flow-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/flow-measurement-cluster.xml
@@ -24,10 +24,22 @@ limitations under the License.
     <define>FLOW_MEASUREMENT_CLUSTER</define>
     <client tick="false" init="false">true</client>
     <server tick="false" init="false">true</server>
-    <attribute side="server" code="0x0000" define="FLOW_MEASURED_VALUE" type="int16u" writable="false" optional="false" isNullable="true">MeasuredValue</attribute>
-    <attribute side="server" code="0x0001" define="FLOW_MIN_MEASURED_VALUE" type="int16u" writable="false" optional="false" isNullable="true">MinMeasuredValue</attribute>
-    <attribute side="server" code="0x0002" define="FLOW_MAX_MEASURED_VALUE" type="int16u" writable="false" optional="false" isNullable="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="FLOW_TOLERANCE" type="int16u" min="0x0000" max="0x0800" writable="false" default="0" optional="true">Tolerance</attribute>
+    <attribute side="server" code="0x0000" define="FLOW_MEASURED_VALUE" type="int16u" isNullable="true">
+      <description>MeasuredValue</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="FLOW_MIN_MEASURED_VALUE" type="int16u" isNullable="true">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="FLOW_MAX_MEASURED_VALUE" type="int16u" isNullable="true">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="FLOW_TOLERANCE" type="int16u" max="0x0800" default="0" optional="true">
+      <description>Tolerance</description>
+      <optionalConform/>
+    </attribute>
   </cluster>
 
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/general-commissioning-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/general-commissioning-cluster.xml
@@ -56,41 +56,86 @@ limitations under the License.
       <description>Breadcrumb</description>
       <access op="read" privilege="view"/>
       <access op="write" privilege="administer"/>
+      <mandatoryConform/>
     </attribute>
-    <attribute side="server" code="0x01" define="BASIC_COMMISSIONING_INFO" type="BasicCommissioningInfo" writable="false" optional="false">BasicCommissioningInfo</attribute>
-    <attribute side="server" code="0x02" define="REGULATORY_CONFIG" type="RegulatoryLocationTypeEnum" writable="false" optional="false">RegulatoryConfig</attribute>
-    <attribute side="server" code="0x03" define="LOCATION_CAPABILITY" type="RegulatoryLocationTypeEnum" writable="false" optional="false">LocationCapability</attribute>
-    <attribute side="server" code="0x04" define="SUPPORTS_CONCURRENT_CONNECTION" type="boolean" writable="false" default="1" optional="false">SupportsConcurrentConnection</attribute>
-    <attribute side="server" code="0x05" define="TC_ACCEPTED_VERSION" type="int16u" writable="false" optional="true" apiMaturity="provisional">
+    <attribute side="server" code="0x01" define="BASIC_COMMISSIONING_INFO" type="BasicCommissioningInfo">
+      <description>BasicCommissioningInfo</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x02" define="REGULATORY_CONFIG" type="RegulatoryLocationTypeEnum">
+      <description>RegulatoryConfig</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x03" define="LOCATION_CAPABILITY" type="RegulatoryLocationTypeEnum">
+      <description>LocationCapability</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x04" define="SUPPORTS_CONCURRENT_CONNECTION" type="boolean" default="1">
+      <description>SupportsConcurrentConnection</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x05" define="TC_ACCEPTED_VERSION" type="int16u" optional="true" apiMaturity="provisional">
       <description>TCAcceptedVersion</description>
       <access op="read" privilege="administer"/>
+      <otherwiseConform>
+        <provisionalConform/>
+        <mandatoryConform>
+          <feature name="TC"/>
+        </mandatoryConform>
+      </otherwiseConform>
     </attribute>
     <attribute side="server" code="0x06" define="TC_MIN_REQUIRED_VERSION" type="int16u" writable="false" optional="true" apiMaturity="provisional">
       <description>TCMinRequiredVersion</description>
       <access op="read" privilege="administer"/>
+      <otherwiseConform>
+        <provisionalConform/>
+        <mandatoryConform>
+          <feature name="TC"/>
+        </mandatoryConform>
+      </otherwiseConform>
     </attribute>
     <attribute side="server" code="0x07" define="TC_ACKNOWLEDGEMENTS" type="bitmap16" writable="false" default="0x0000" optional="true" apiMaturity="provisional">
       <description>TCAcknowledgements</description>
       <access op="read" privilege="administer"/>
+      <otherwiseConform>
+        <provisionalConform/>
+        <mandatoryConform>
+          <feature name="TC"/>
+        </mandatoryConform>
+      </otherwiseConform>
     </attribute>
     <attribute side="server" code="0x08" define="TC_ACKNOWLEDGEMENTS_REQUIRED" type="boolean" writable="false" optional="true" apiMaturity="provisional">
       <description>TCAcknowledgementsRequired</description>
       <access op="read" privilege="administer"/>
+      <otherwiseConform>
+        <provisionalConform/>
+        <mandatoryConform>
+          <feature name="TC"/>
+        </mandatoryConform>
+      </otherwiseConform>
     </attribute>
     <attribute side="server" code="0x09" define="TC_UPDATE_DEADLINE" type="int32u" writable="false" optional="true" apiMaturity="provisional">
       <description>TCUpdateDeadline</description>
       <access op="read" privilege="administer"/>
+      <otherwiseConform>
+        <provisionalConform/>
+        <mandatoryConform>
+          <feature name="TC"/>
+        </mandatoryConform>
+      </otherwiseConform>
     </attribute>
     <command source="client" code="0x00" name="ArmFailSafe" response="ArmFailSafeResponse" optional="false" cli="chip fabric_commissioning armfailsafe">
       <description>Arm the persistent fail-safe timer with an expiry time of now + ExpiryLengthSeconds using device clock</description>
       <arg name="ExpiryLengthSeconds" type="int16u"/>
       <arg name="Breadcrumb" type="int64u"/>
       <access op="invoke" privilege="administer"/>
+      <mandatoryConform/>
     </command>
     <command source="server" code="0x01" name="ArmFailSafeResponse" optional="false" cli="chip fabric_commissioning armfailsaferesponse">
       <description>Success/failure response for ArmFailSafe command</description>
       <arg name="ErrorCode" type="CommissioningErrorEnum"/>
       <arg name="DebugText" type="char_string" length="128"/>
+      <mandatoryConform/>
     </command>
     <command source="client" code="0x02" name="SetRegulatoryConfig" response="SetRegulatoryConfigResponse" cli="chip fabric_commissioning setregulatoryconfig">
       <description>Set the regulatory configuration to be used during commissioning</description>
@@ -98,30 +143,46 @@ limitations under the License.
       <arg name="CountryCode" type="char_string" length="2"/>
       <arg name="Breadcrumb" type="int64u"/>
       <access op="invoke" privilege="administer"/>
+      <mandatoryConform/>
     </command>
     <command source="server" code="0x03" name="SetRegulatoryConfigResponse" cli="chip fabric_commissioning setregulatoryconfigresponse">
       <description>Success/failure response for SetRegulatoryConfig command</description>
       <arg name="ErrorCode" type="CommissioningErrorEnum"/>
       <arg name="DebugText" type="char_string"/>
+      <mandatoryConform/>
     </command>
     <command source="client" code="0x04" name="CommissioningComplete" response="CommissioningCompleteResponse" isFabricScoped="true" optional="false" cli="chip fabric_commissioning commissioningcomplete">
       <description>Signals the Server that the Client has successfully completed all steps of Commissioning/Recofiguration needed during fail-safe period.</description>
       <access op="invoke" privilege="administer"/>
+      <mandatoryConform/>
     </command>
     <command source="server" code="0x05" name="CommissioningCompleteResponse" optional="false" cli="chip fabric_commissioning commissioningcompleteresponse">
       <description>Indicates to client whether CommissioningComplete command succeeded</description>
       <arg name="ErrorCode" type="CommissioningErrorEnum"/>
       <arg name="DebugText" type="char_string"/>
+      <mandatoryConform/>
     </command>
     <command source="client" code="0x06" name="SetTCAcknowledgements" optional="true" response="SetTCAcknowledgementsResponse" cli="chip fabric_commissioning settcacknowledgements" apiMaturity="provisional">
       <description>This command sets the user acknowledgements received in the Enhanced Setup Flow Terms and Conditions into the node.</description>
       <arg name="TCVersion" type="int16u"/>
       <arg name="TCUserResponse" type="bitmap16"/>
       <access op="invoke" privilege="administer"/>
+      <otherwiseConform>
+        <provisionalConform/>
+        <mandatoryConform>
+          <feature name="TC"/>
+        </mandatoryConform>
+      </otherwiseConform>
     </command>
     <command source="server" code="0x07" name="SetTCAcknowledgementsResponse" optional="true" cli="chip fabric_commissioning settcacknowledgementsresponse" apiMaturity="provisional">
       <description>This command is used to convey the result from SetTCAcknowledgements.</description>
       <arg name="ErrorCode" type="CommissioningErrorEnum"/>
+      <otherwiseConform>
+        <provisionalConform/>
+        <mandatoryConform>
+          <feature name="TC"/>
+        </mandatoryConform>
+      </otherwiseConform>
     </command>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/general-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/general-diagnostics-cluster.xml
@@ -92,17 +92,44 @@ limitations under the License.
       </feature>
     </features>
 
-    <attribute side="server" code="0x00" define="NETWORK_INTERFACES" type="array" entryType="NetworkInterface" length="8" writable="false" optional="false">NetworkInterfaces</attribute>
-    <attribute side="server" code="0x01" define="REBOOT_COUNT" type="int16u" writable="false" default="0x0000" optional="false">RebootCount</attribute>
+    <attribute side="server" code="0x00" define="NETWORK_INTERFACES" type="array" entryType="NetworkInterface" length="8">
+      <description>NetworkInterfaces</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x01" define="REBOOT_COUNT" type="int16u">
+      <description>RebootCount</description>
+      <mandatoryConform/>
+    </attribute>
     <!-- ***NOTE***: UpTime attribute is mandatory starting at Rev >= 2, but because of backwards compatibility, has to be optional here.
          The device type config and cert tests (TC-DGGEN-1.1/2.1) ensure that it is present. -->
-    <attribute side="server" code="0x02" define="UP_TIME" type="int64u" writable="false" default="0x0000000000000000" optional="true">UpTime</attribute>
-    <attribute side="server" code="0x03" define="TOTAL_OPERATIONAL_HOURS" type="int32u" writable="false" default="0x00000000" optional="true">TotalOperationalHours</attribute>
-    <attribute side="server" code="0x04" define="BOOT_REASONS" type="BootReasonEnum" writable="false" optional="true">BootReason</attribute>
-    <attribute side="server" code="0x05" define="ACTIVE_HARDWARE_FAULTS" type="array" entryType="HardwareFaultEnum" writable="false" optional="true">ActiveHardwareFaults</attribute>
-    <attribute side="server" code="0x06" define="ACTIVE_RADIO_FAULTS" type="array" entryType="RadioFaultEnum" writable="false" optional="true">ActiveRadioFaults</attribute>
-    <attribute side="server" code="0x07" define="ACTIVE_NETWORK_FAULTS" type="array" entryType="NetworkFaultEnum" writable="false" optional="true">ActiveNetworkFaults</attribute>
-    <attribute side="server" code="0x08" define="TEST_EVENT_TRIGGERS_ENABLED" type="boolean" writable="false" optional="false">TestEventTriggersEnabled</attribute>
+    <attribute side="server" code="0x02" define="UP_TIME" type="int64u" optional="true">
+      <description>UpTime</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x03" define="TOTAL_OPERATIONAL_HOURS" type="int32u" optional="true">
+      <description>TotalOperationalHours</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x04" define="BOOT_REASONS" type="BootReasonEnum" optional="true">
+      <description>BootReason</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x05" define="ACTIVE_HARDWARE_FAULTS" type="array" entryType="HardwareFaultEnum" optional="true">
+      <description>ActiveHardwareFaults</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x06" define="ACTIVE_RADIO_FAULTS" type="array" entryType="RadioFaultEnum" optional="true">
+      <description>ActiveRadioFaults</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x07" define="ACTIVE_NETWORK_FAULTS" type="array" entryType="NetworkFaultEnum" optional="true">
+      <description>ActiveNetworkFaults</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x08" define="TEST_EVENT_TRIGGERS_ENABLED" type="boolean">
+      <description>TestEventTriggersEnabled</description>
+      <mandatoryConform/>
+    </attribute>
     <!--
         WARNING !!!!! Attribute 0x0009 (previously AverageWearCount, see #30002/#29285)
         was previously mistakenly added in SDK without being in spec and WAS REMOVED.
@@ -118,16 +145,19 @@ limitations under the License.
       <arg name="EnableKey" type="octet_string" length="16"/>
       <arg name="EventTrigger" type="int64u"/>
       <access op="invoke" role="manage"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x01" name="TimeSnapshot" response="TimeSnapshotResponse" optional="false" apiMaturity="provisional">
       <description>Take a snapshot of system time and epoch time.</description>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x02" name="TimeSnapshotResponse" optional="false" apiMaturity="provisional">
       <description>Response for the TimeSnapshot command.</description>
       <arg name="SystemTimeMs" type="systime_ms" optional="false"/>
       <arg name="PosixTimeMs" type="posix_ms" isNullable="true" optional="false"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x03" name="PayloadTestRequest" response="PayloadTestResponse" optional="true" apiMaturity="provisional">
@@ -135,31 +165,41 @@ limitations under the License.
       <arg name="EnableKey" type="octet_string" length="16"/>
       <arg name="Value" type="int8u"/>
       <arg name="Count" type="int16u" max="2048"/>
+      <mandatoryConform>
+        <feature name="DMTEST"/>
+      </mandatoryConform>
     </command>
 
-    <command source="server" code="0x04" name="PayloadTestResponse" optional="true" apiMaturity="provisional">
+   <command source="server" code="0x04" name="PayloadTestResponse" optional="true" apiMaturity="provisional">
       <description>Response for the PayloadTestRequest command.</description>
       <arg name="Payload" type="octet_string" max="2048" optional="false"/>
+      <mandatoryConform>
+        <feature name="DMTEST"/>
+      </mandatoryConform>
     </command>
 
     <event side="server" code="0x00" name="HardwareFaultChange" priority="critical" optional="true">
       <description>Indicate a change in the set of hardware faults currently detected by the Node.</description>
       <field id="0" name="Current" type="HardwareFaultEnum" array="true"/>
       <field id="1" name="Previous" type="HardwareFaultEnum" array="true"/>
+      <optionalConform/>
     </event>
     <event side="server" code="0x01" name="RadioFaultChange" priority="critical" optional="true">
       <description>Indicate a change in the set of radio faults currently detected by the Node.</description>
       <field id="0" name="Current" type="RadioFaultEnum" array="true"/>
       <field id="1" name="Previous" type="RadioFaultEnum" array="true"/>
+      <optionalConform/>
     </event>
     <event side="server" code="0x02" name="NetworkFaultChange" priority="critical" optional="true">
       <description>Indicate a change in the set of network faults currently detected by the Node.</description>
       <field id="0" name="Current" type="NetworkFaultEnum" array="true"/>
       <field id="1" name="Previous" type="NetworkFaultEnum" array="true"/>
+      <optionalConform/>
     </event>
     <event side="server" code="0x03" name="BootReason" priority="critical" optional="false">
       <description>Indicate the reason that caused the device to start-up.</description>
       <field id="0" name="BootReason" type="BootReasonEnum"/>
+      <mandatoryConform/>
     </event>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/group-key-mgmt-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/group-key-mgmt-cluster.xml
@@ -65,21 +65,33 @@ limitations under the License.
       <description>GroupKeyMap</description>
       <access op="read" privilege="view"/>
       <access op="write" privilege="manage"/>
+      <mandatoryConform/>
     </attribute>
-    <attribute side="server" code="0x0001" define="GROUP_TABLE" type="array" length="254" entryType="GroupInfoMapStruct" writable="false" optional="false">GroupTable</attribute>
-    <attribute side="server" code="0x0002" define="MAX_GROUPS_PER_FABRIC" type="int16u" writable="false" optional="false">MaxGroupsPerFabric</attribute>
-    <attribute side="server" code="0x0003" define="MAX_GROUP_KEYS_PER_FABRIC" type="int16u" writable="false" optional="false">MaxGroupKeysPerFabric</attribute>
-
+    <attribute side="server" code="0x0001" define="GROUP_TABLE" type="array" length="254" entryType="GroupInfoMapStruct">
+      <description>GroupTable</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MAX_GROUPS_PER_FABRIC" type="int16u">
+      <description>MaxGroupsPerFabric</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="MAX_GROUP_KEYS_PER_FABRIC" type="int16u">
+      <description>MaxGroupKeysPerFabric</description>
+      <mandatoryConform/>
+    </attribute>
+    
     <command source="client" code="0x00" name="KeySetWrite" isFabricScoped="true" optional="false" cli="zcl GroupKeyManagement KeySetWrite">
       <description>Write a new set of keys for the given key set id.</description>
       <arg name="GroupKeySet" type="GroupKeySetStruct"/>
       <access op="invoke" privilege="administer"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x01" name="KeySetRead" isFabricScoped="true" response="KeySetReadResponse" optional="false" cli="zcl GroupKeyManagement KeySetRead">
       <description>Read the keys for a given key set id.</description>
       <arg name="GroupKeySetID" type="int16u"/>
       <access op="invoke" privilege="administer"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x02" name="KeySetReadResponse" optional="false" disableDefaultResponse="true">
@@ -87,24 +99,28 @@ limitations under the License.
        Response to KeySetRead
       </description>
       <arg name="GroupKeySet" type="GroupKeySetStruct"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x03" name="KeySetRemove" isFabricScoped="true" optional="false" cli="zcl GroupKeyManagement KeySetRemove">
       <description>Revoke a Root Key from a Group</description>
       <arg name="GroupKeySetID" type="int16u"/>
       <access op="invoke" privilege="administer"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x04" name="KeySetReadAllIndices" response="KeySetReadAllIndicesResponse" isFabricScoped="true" optional="false" cli="zcl GroupKeyManagement KeySetReadAllIndices">
       <description>Return the list of Group Key Sets associated with the accessing fabric</description>
       <access op="invoke" privilege="administer"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x05" name="KeySetReadAllIndicesResponse" optional="false" disableDefaultResponse="true">
       <description>
         Reseponse to KeySetReadAllIndices
       </description>
-        <arg name="GroupKeySetIDs" type="int16u" array="true"/>
+      <arg name="GroupKeySetIDs" type="int16u" array="true"/>
+      <mandatoryConform/>
     </command>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/groups-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/groups-cluster.xml
@@ -40,8 +40,11 @@ limitations under the License.
       </feature>
     </features>
 
-    <attribute side="server" code="0x0000" define="GROUP_NAME_SUPPORT" type="NameSupportBitmap" min="0x00" max="0x80" writable="false" optional="false">NameSupport</attribute>
-
+    <attribute side="server" code="0x0000" define="GROUP_NAME_SUPPORT" type="NameSupportBitmap" min="0x00" max="0x80">
+      <description>NameSupport</description>
+      <mandatoryConform/>
+    </attribute>
+    
     <command source="client" code="0x00" name="AddGroup" response="AddGroupResponse" isFabricScoped="true" optional="false" cli="zcl groups add">
       <description>
         Command description for AddGroup
@@ -49,6 +52,7 @@ limitations under the License.
       <access op="invoke" role="manage"/>
       <arg name="GroupID" type="group_id"/>
       <arg name="GroupName" type="char_string" length="16"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x01" name="ViewGroup" response="ViewGroupResponse" isFabricScoped="true" optional="false" cli="zcl groups view">
@@ -56,6 +60,7 @@ limitations under the License.
         Command description for ViewGroup
       </description>
       <arg name="GroupID" type="group_id"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x02" name="GetGroupMembership" response="GetGroupMembershipResponse" cliFunctionName="zclGroupsGetCommand" isFabricScoped="true" optional="false" cli="zcl groups get">
@@ -63,6 +68,7 @@ limitations under the License.
         Command description for GetGroupMembership
       </description>
       <arg name="GroupList" type="group_id" array="true"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x03" name="RemoveGroup" response="RemoveGroupResponse" isFabricScoped="true" optional="false" cli="zcl groups remove">
@@ -71,6 +77,7 @@ limitations under the License.
       </description>
       <access op="invoke" role="manage"/>
       <arg name="GroupID" type="group_id"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x04" name="RemoveAllGroups" isFabricScoped="true" optional="false" cli="zcl groups rmall">
@@ -78,6 +85,7 @@ limitations under the License.
         Command description for RemoveAllGroups
       </description>
       <access op="invoke" role="manage"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x05" name="AddGroupIfIdentifying" isFabricScoped="true" optional="false" cli="zcl groups add-if-id">
@@ -87,6 +95,7 @@ limitations under the License.
       <access op="invoke" role="manage"/>
       <arg name="GroupID" type="group_id"/>
       <arg name="GroupName" length="16" type="char_string"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x00" name="AddGroupResponse" optional="false" disableDefaultResponse="true">
@@ -95,6 +104,7 @@ limitations under the License.
       </description>
       <arg name="Status" type="enum8"/>
       <arg name="GroupID" type="group_id"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x01" name="ViewGroupResponse" optional="false" disableDefaultResponse="true">
@@ -104,6 +114,7 @@ limitations under the License.
       <arg name="Status" type="enum8"/>
       <arg name="GroupID" type="group_id"/>
       <arg name="GroupName" length="16" type="char_string"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x02" name="GetGroupMembershipResponse" optional="false" disableDefaultResponse="true">
@@ -112,6 +123,7 @@ limitations under the License.
       </description>
       <arg name="Capacity" type="int8u" isNullable="true"/>
       <arg name="GroupList" type="group_id" array="true"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x03" name="RemoveGroupResponse" optional="false" disableDefaultResponse="true">
@@ -120,6 +132,7 @@ limitations under the License.
       </description>
       <arg name="Status" type="enum8"/>
       <arg name="GroupID" type="group_id"/>
+      <mandatoryConform/>
     </command>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/icd-management-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/icd-management-cluster.xml
@@ -59,102 +59,166 @@ limitations under the License.
         <item value="1" name="LIT" />
     </enum>
 
-    <cluster>
-        <domain>General</domain>
-        <name>ICD Management</name>
-        <code>0x0046</code>
-        <define>ICD_MANAGEMENT_CLUSTER</define>
-        <description>Allows servers to ensure that listed clients are notified when a server is available for communication.</description>
+  <cluster>
+    <domain>General</domain>
+    <name>ICD Management</name>
+    <code>0x0046</code>
+    <define>ICD_MANAGEMENT_CLUSTER</define>
+    <description>Allows servers to ensure that listed clients are notified when a server is available for communication.</description>
+    
+    <!-- Cluster feature map -->
+    <globalAttribute side="server" code="0xFFFC" value="0x0000"/>
+    <!-- Current cluster version -->
+    <globalAttribute side="either" code="0xFFFD" value="3"/>
+    
+    <features>
+      <feature bit="0" code="CIP" name="CheckInProtocolSupport" summary="Device supports attributes and commands for the Check-In Protocol support.">
+        <otherwiseConform>
+          <provisionalConform/>
+          <mandatoryConform>
+            <feature name="LITS"/>
+          </mandatoryConform>
+          <optionalConform/>
+        </otherwiseConform>
+      </feature>
+      <feature bit="1" code="UAT" name="UserActiveModeTrigger" summary="Device supports the user active mode trigger feature.">
+        <otherwiseConform>
+          <provisionalConform/>
+          <mandatoryConform>
+            <feature name="LITS"/>
+          </mandatoryConform>
+          <optionalConform/>
+        </otherwiseConform>
+      </feature>
+      <feature bit="2" code="LITS" name="LongIdleTimeSupport" summary="Device supports operating as a Long Idle Time ICD.">
+        <otherwiseConform>
+          <provisionalConform/>
+          <optionalConform/>
+        </otherwiseConform>
+      </feature>
+      <feature bit="3" code="DSLS" name="DynamicSitLitSupport" summary="Device supports dynamic switching from SIT to LIT operating modes.">
+        <otherwiseConform>
+          <provisionalConform/>
+          <optionalConform>
+            <feature name="LITS"/>
+          </optionalConform>
+        </otherwiseConform>
+      </feature>
+    </features>
 
-        <!-- Cluster feature map -->
-        <globalAttribute side="server" code="0xFFFC" value="0x0000"/>
-        <!-- Current cluster version -->
-        <globalAttribute side="either" code="0xFFFD" value="3"/>
+    <attribute side="server" code="0x00" define="IDLE_MODE_DURATION" type="int32u" min="1" max="64800" default="1">
+      <description>IdleModeDuration</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x01" define="ACTIVE_MODE_DURATION" type="int32u" default="300">
+      <description>ActiveModeDuration</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x02" define="ACTIVE_MODE_THRESHOLD" type="int16u" default="300">
+      <description>ActiveModeThreshold</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x03" define="REGISTERED_CLIENTS" type="array" entryType="MonitoringRegistrationStruct" optional="true">
+      <description>RegisteredClients</description>
+      <access op="read" privilege="administer"/>
+      <mandatoryConform>
+        <feature name="CIP"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x04" define="ICD_COUNTER" type="int32u" default="0" optional="true">
+      <description>ICDCounter</description>
+      <access op="read" privilege="administer"/>
+      <mandatoryConform>
+        <feature name="CIP"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x05" define="CLIENTS_SUPPORTED_PER_FABRIC" type="int16u" min="1" default="1" optional="true">
+      <description>ClientsSupportedPerFabric</description>
+      <mandatoryConform>
+        <feature name="CIP"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x06" define="USER_ACTIVE_MODE_TRIGGER_HINT" type="UserActiveModeTriggerBitmap" optional="true" apiMaturity="provisional">
+      <description>UserActiveModeTriggerHint</description>
+      <otherwiseConform>
+        <provisionalConform/>
+        <mandatoryConform>
+          <feature name="UAT"/>
+        </mandatoryConform>
+      </otherwiseConform>
+    </attribute>
+    <attribute side="server" code="0x07" define="USER_ACTIVE_MODE_TRIGGER_INSTRUCTION" type="char_string" length="128" optional="true" apiMaturity="provisional">
+      <description>UserActiveModeTriggerInstruction</description>
+      <provisionalConform/>
+    </attribute>
+    <attribute side="server" code="0x08" define="OPERATING_MODE" type="OperatingModeEnum" default="0" optional="true" apiMaturity="provisional">
+      <description>OperatingMode</description>
+      <otherwiseConform>
+        <provisionalConform/>
+        <mandatoryConform>
+          <feature name="LITS"/>
+        </mandatoryConform>
+      </otherwiseConform>
+    </attribute>
+    <attribute side="server" code="0x09" define="MAXIMUM_CHECK_IN_BACK_OFF" type="int32u" default="1" max="64800" optional="true" apiMaturity="provisional">
+      <description>MaximumCheckInBackOff</description>
+      <mandatoryConform>
+        <feature name="CIP"/>
+      </mandatoryConform>
+    </attribute>
 
-        <features>
-            <feature bit="0" code="CIP" name="CheckInProtocolSupport" summary="Device supports attributes and commands for the Check-In Protocol support.">
-            <otherwiseConform>
-                <provisionalConform/>
-                <mandatoryConform>
-                <feature name="LITS"/>
-                </mandatoryConform>
-                <optionalConform/>
-            </otherwiseConform>
-            </feature>
-            <feature bit="1" code="UAT" name="UserActiveModeTrigger" summary="Device supports the user active mode trigger feature.">
-            <otherwiseConform>
-                <provisionalConform/>
-                <mandatoryConform>
-                <feature name="LITS"/>
-                </mandatoryConform>
-                <optionalConform/>
-            </otherwiseConform>
-            </feature>
-            <feature bit="2" code="LITS" name="LongIdleTimeSupport" summary="Device supports operating as a Long Idle Time ICD.">
-            <otherwiseConform>
-                <provisionalConform/>
-                <optionalConform/>
-            </otherwiseConform>
-            </feature>
-            <feature bit="3" code="DSLS" name="DynamicSitLitSupport" summary="Device supports dynamic switching from SIT to LIT operating modes.">
->               <otherwiseConform>
->                   <provisionalConform/>
->                   <optionalConform>
->                       <feature name="LITS"/>
->                   </optionalConform>
-                </otherwiseConform>
-            </feature>
-        </features>
+    <command source="client" code="0x00" name="RegisterClient" response="RegisterClientResponse" isFabricScoped="true" optional="true">
+      <description>Register a client to the end device</description>
+      <arg name="CheckInNodeID" type="node_id" optional="false"/>
+      <arg name="MonitoredSubject" type="int64u" optional="false"/>
+      <arg name="Key" type="octet_string" length="16" optional="false"/>
+      <arg name="VerificationKey" type="octet_string" length="16" optional="true"/>
+      <arg name="ClientType" type="ClientTypeEnum" optional="false"/>
+      <access op="invoke" privilege="manage"/>
+      <mandatoryConform>
+        <feature name="CIP"/>
+      </mandatoryConform>
+    </command>
 
+    <command source="server" code="0x01" name="RegisterClientResponse" optional="true" disableDefaultResponse="true">
+      <description>RegisterClient response command</description>
+      <arg name="ICDCounter" type="int32u" isNullable="false"/>
+      <mandatoryConform>
+        <feature name="CIP"/>
+      </mandatoryConform>
+    </command>
 
-        <attribute side="server" code="0x00" define="IDLE_MODE_DURATION" type="int32u" min="1" max="64800" default="1" writable="false" optional="false" isNullable="false">IdleModeDuration</attribute>
-        <attribute side="server" code="0x01" define="ACTIVE_MODE_DURATION" type="int32u" default="300" writable="false" optional="false" isNullable="false">ActiveModeDuration</attribute>
-        <attribute side="server" code="0x02" define="ACTIVE_MODE_THRESHOLD" type="int16u" default="300" writable="false" optional="false" isNullable="false">ActiveModeThreshold</attribute>
-        <attribute side="server" code="0x03" define="REGISTERED_CLIENTS" type="array" entryType="MonitoringRegistrationStruct" writable="false" optional="true" isNullable="false">
-            <description>RegisteredClients</description>
-            <access op="read" privilege="administer"/>
-        </attribute>
-        <attribute side="server" code="0x04" define="ICD_COUNTER" type="int32u" writable="false" default="0" optional="true" isNullable="false">
-            <description>ICDCounter</description>
-            <access op="read" privilege="administer"/>
-        </attribute>
-        <attribute side="server" code="0x05" define="CLIENTS_SUPPORTED_PER_FABRIC" type="int16u" min="1" default="1" writable="false" optional="true" isNullable="false">ClientsSupportedPerFabric</attribute>
-        <attribute side="server" code="0x06" define="USER_ACTIVE_MODE_TRIGGER_HINT" type="UserActiveModeTriggerBitmap" writable="false" optional="true" isNullable="false" apiMaturity="provisional">UserActiveModeTriggerHint</attribute>
-        <attribute side="server" code="0x07" define="USER_ACTIVE_MODE_TRIGGER_INSTRUCTION" type="char_string" length="128" writable="false" optional="true" isNullable="false" apiMaturity="provisional">UserActiveModeTriggerInstruction</attribute>
-        <attribute side="server" code="0x08" define="OPERATING_MODE" type="OperatingModeEnum" default="0" writable="false" optional="true" isNullable="false" apiMaturity="provisional">OperatingMode</attribute>
-        <attribute side="server" code="0x09" define="MAXIMUM_CHECK_IN_BACK_OFF" type="int32u" default="1" max="64800" optional="true" isNullable="false" apiMaturity="provisional">MaximumCheckInBackOff</attribute>
+    <command source="client" code="0x02" name="UnregisterClient" isFabricScoped="true" optional="true">
+      <description>Unregister a client from an end device</description>
+      <arg name="CheckInNodeID" type="node_id"/>
+      <arg name="VerificationKey" type="octet_string" length="16" optional="true"/>
+      <access op="invoke" privilege="manage"/>
+      <mandatoryConform>
+        <feature name="CIP"/>
+      </mandatoryConform>
+    </command>
 
-        <command source="client" code="0x00" name="RegisterClient" response="RegisterClientResponse" isFabricScoped="true" optional="true">
-            <description>Register a client to the end device</description>
-            <arg name="CheckInNodeID" type="node_id" optional="false"/>
-            <arg name="MonitoredSubject" type="int64u" optional="false"/>
-            <arg name="Key" type="octet_string" length="16" optional="false"/>
-            <arg name="VerificationKey" type="octet_string" length="16" optional="true"/>
-            <arg name="ClientType" type="ClientTypeEnum" optional="false"/>
-            <access op="invoke" privilege="manage"/>
-        </command>
+    <command source="client" code="0x03" name="StayActiveRequest" response="StayActiveResponse" optional="true">
+      <description>Request the end device to stay in Active Mode for an additional ActiveModeThreshold</description>
+      <access op="invoke" privilege="manage"/>
+      <arg name="StayActiveDuration" type="int32u" isNullable="false"/>
+      <otherwiseConform>
+        <mandatoryConform>
+          <feature name="LITS"/>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </command>
 
-        <command source="server" code="0x01" name="RegisterClientResponse" optional="true" disableDefaultResponse="true">
-            <description>RegisterClient response command</description>
-            <arg name="ICDCounter" type="int32u" isNullable="false"/>
-        </command>
-
-        <command source="client" code="0x02" name="UnregisterClient" isFabricScoped="true" optional="true">
-            <description>Unregister a client from an end device</description>
-            <arg name="CheckInNodeID" type="node_id"/>
-            <arg name="VerificationKey" type="octet_string" length="16" optional="true"/>
-            <access op="invoke" privilege="manage"/>
-        </command>
-
-        <command source="client" code="0x03" name="StayActiveRequest" response="StayActiveResponse" optional="true">
-            <description>Request the end device to stay in Active Mode for an additional ActiveModeThreshold</description>
-            <access op="invoke" privilege="manage"/>
-            <arg name="StayActiveDuration" type="int32u" isNullable="false"/>
-        </command>
-
-        <command source="server" code="0x04" name="StayActiveResponse" optional="true" disableDefaultResponse="true">
-            <description>StayActiveRequest response command</description>
-            <arg name="PromisedActiveDuration" type="int32u" isNullable="false"/>
-        </command>
-    </cluster>
+    <command source="server" code="0x04" name="StayActiveResponse" optional="true" disableDefaultResponse="true">
+      <description>StayActiveRequest response command</description>
+      <arg name="PromisedActiveDuration" type="int32u" isNullable="false"/>
+      <otherwiseConform>
+        <mandatoryConform>
+          <feature name="LITS"/>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </command>
+  </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/identify-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/identify-cluster.xml
@@ -51,16 +51,23 @@ limitations under the License.
     <client tick="false" init="false">true</client>
     <server tick="false" init="false">true</server>
     <globalAttribute side="either" code="0xFFFD" value="4"/>
-
-    <attribute side="server" code="0x0000" define="IDENTIFY_TIME" type="int16u" writable="true"  default="0x0" optional="false">IdentifyTime</attribute>
-    <attribute side="server" code="0x0001" define="IDENTIFY_TYPE" type="IdentifyTypeEnum" writable="false" default="0x00" optional="false">IdentifyType</attribute>
-
+    
+    <attribute side="server" code="0x0000" define="IDENTIFY_TIME" type="int16u" writable="true" default="0x0">
+      <description>IdentifyTime</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="IDENTIFY_TYPE" type="IdentifyTypeEnum" default="0x00">
+      <description>IdentifyType</description>
+      <mandatoryConform/>
+    </attribute>
+    
     <command source="client" code="0x00" name="Identify" optional="false">
       <description>
         Command description for Identify
       </description>
       <arg name="IdentifyTime" type="int16u"/>
       <access op="invoke" privilege="manage"/>
+      <mandatoryConform/>
     </command>
     <command source="client" code="0x40" name="TriggerEffect" optional="true">
       <description>
@@ -69,6 +76,7 @@ limitations under the License.
       <arg name="EffectIdentifier" type="EffectIdentifierEnum"/>
       <arg name="EffectVariant" type="EffectVariantEnum"/>
       <access op="invoke" privilege="manage"/>
+      <optionalConform/>
     </command>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/illuminance-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/illuminance-measurement-cluster.xml
@@ -18,19 +18,34 @@ limitations under the License.
   <domain name="CHIP"/>
 
   <cluster>
-      <name>Illuminance Measurement</name>
-      <domain>Measurement &amp; Sensing</domain>
-      <description>Attributes and commands for configuring the measurement of illuminance, and reporting illuminance measurements.</description>
-      <code>0x0400</code>
-      <define>ILLUMINANCE_MEASUREMENT_CLUSTER</define>
-      <client tick="false" init="false">true</client>
-      <server tick="false" init="false">true</server>
-      <globalAttribute side="either" code="0xFFFD" value="3"/>
-      <attribute side="server" code="0x0000" define="ILLUM_MEASURED_VALUE"     type="int16u" min="0x0000" max="0xFFFF" writable="false" reportable="true" isNullable="true" default="0x0000" optional="false">MeasuredValue</attribute>
-      <attribute side="server" code="0x0001" define="ILLUM_MIN_MEASURED_VALUE" type="int16u" min="0x0001" max="0xFFFD" writable="false"                   isNullable="true"                  optional="false">MinMeasuredValue</attribute>
-      <attribute side="server" code="0x0002" define="ILLUM_MAX_MEASURED_VALUE" type="int16u" min="0x0002" max="0xFFFE" writable="false"                   isNullable="true"                  optional="false">MaxMeasuredValue</attribute>
-      <attribute side="server" code="0x0003" define="ILLUM_TOLERANCE"          type="int16u" min="0x0000" max="0x0800" writable="false"                                                      optional="true" >Tolerance</attribute>
-      <attribute side="server" code="0x0004" define="ILLUM_LIGHT_SENSOR_TYPE"  type="LightSensorTypeEnum"  min="0x00"   max="0xFF"   writable="false"                   isNullable="true" default="0xFF"   optional="true" >LightSensorType</attribute>
+    <name>Illuminance Measurement</name>
+    <domain>Measurement &amp; Sensing</domain>
+    <description>Attributes and commands for configuring the measurement of illuminance, and reporting illuminance measurements.</description>
+    <code>0x0400</code>
+    <define>ILLUMINANCE_MEASUREMENT_CLUSTER</define>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
+    <globalAttribute side="either" code="0xFFFD" value="3"/>
+    <attribute side="server" code="0x0000" define="ILLUM_MEASURED_VALUE" type="int16u" min="0x0000" max="0xFFFF" reportable="true" isNullable="true" default="0x0000">
+      <description>MeasuredValue</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="ILLUM_MIN_MEASURED_VALUE" type="int16u" min="0x0001" max="0xFFFD" isNullable="true">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="ILLUM_MAX_MEASURED_VALUE" type="int16u" min="0x0002" max="0xFFFE" isNullable="true">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="ILLUM_TOLERANCE" type="int16u" min="0x0000" max="0x0800" optional="true">
+      <description>Tolerance</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0004" define="ILLUM_LIGHT_SENSOR_TYPE" type="LightSensorTypeEnum" min="0x00" max="0xFF" isNullable="true" default="0xFF" optional="true">
+      <description>LightSensorType</description>
+      <optionalConform/>
+    </attribute>
   </cluster>
 
   <enum name="LightSensorTypeEnum" type="enum8">

--- a/src/app/zap-templates/zcl/data-model/chip/keypad-input-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/keypad-input-cluster.xml
@@ -40,11 +40,13 @@ limitations under the License.
     <command source="client" code="0x00" name="SendKey" response="SendKeyResponse" optional="false">
       <description>Upon receipt, this SHALL process a keycode as input to the media device.</description>
       <arg name="KeyCode" type="CECKeyCodeEnum"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x01" name="SendKeyResponse" optional="false">
       <description>This command SHALL be generated in response to a SendKey Request command.</description>
       <arg name="Status" type="StatusEnum"/>
+      <mandatoryConform/>
     </command>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/laundry-dryer-controls-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/laundry-dryer-controls-cluster.xml
@@ -36,9 +36,15 @@ limitations under the License.
         <description>This cluster provides a way to access options associated with the operation of
             a laundry dryer device type.</description>
 
-        <globalAttribute side="either" code="0xFFFD" value="1" />
-
-        <attribute side="server" code="0x0000" define="SUPPORTED_DRYNESS_LEVELS" type="array" entryType="DrynessLevelEnum" writable="false" isNullable="false" optional="false" min="0x01" max="0x04">SupportedDrynessLevels</attribute>
-        <attribute side="server" code="0x0001" define="SELECTED_DRYNESS_LEVEL" type="DrynessLevelEnum"      writable="true"  isNullable="true"   optional="false">SelectedDrynessLevel</attribute>
-    </cluster>
+    <globalAttribute side="either" code="0xFFFD" value="1"/>
+    
+    <attribute side="server" code="0x0000" define="SUPPORTED_DRYNESS_LEVELS" type="array" entryType="DrynessLevelEnum" min="0x01" max="0x04">
+      <description>SupportedDrynessLevels</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="SELECTED_DRYNESS_LEVEL" type="DrynessLevelEnum" writable="true" isNullable="true">
+      <description>SelectedDrynessLevel</description>
+      <mandatoryConform/>
+    </attribute>
+  </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/laundry-washer-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/laundry-washer-mode-cluster.xml
@@ -58,11 +58,17 @@ limitations under the License.
     </features>
 
     <!-- Base data types -->
-    <attribute side="server" code="0x0000" define="SUPPORTED_MODES"  type="array" entryType="ModeOptionStruct" writable="false" optional="false" isNullable="false" length="255">SupportedModes</attribute>
-    <attribute side="server" code="0x0001" define="CURRENT_MODE"     type="int8u"                              writable="false" optional="false" isNullable="false" reportable="true">CurrentMode</attribute>
+    <attribute side="server" code="0x0000" define="SUPPORTED_MODES" type="array" entryType="ModeOptionStruct" length="255">
+      <description>SupportedModes</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="CURRENT_MODE" type="int8u" reportable="true">
+      <description>CurrentMode</description>
+      <mandatoryConform/>
+    </attribute>
     <attribute side="server" code="0x0002" define="START_UP_MODE"    type="int8u"                              writable="true"  optional="true"  isNullable="true">StartUpMode</attribute>
     <attribute side="server" code="0x0003" define="ON_MODE"          type="int8u"                              writable="true"  optional="true"  isNullable="true">OnMode</attribute>
-
+    
     <!-- Commands -->
     <command source="client" code="0x00" name="ChangeToMode" response="ChangeToModeResponse" optional="false">
       <description>
@@ -70,6 +76,7 @@ limitations under the License.
         On receipt of this command the device SHALL respond with a ChangeToModeResponse command.
       </description>
       <arg name="NewMode" type="int8u" optional="false"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x01" name="ChangeToModeResponse" disableDefaultResponse="true" optional="false">
@@ -78,6 +85,7 @@ limitations under the License.
       </description>
       <arg name="Status"     type="enum8"                   optional="false"/>
       <arg name="StatusText" type="char_string" lenght="64" optional="true"/>
+      <mandatoryConform/>
     </command>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/level-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/level-control-cluster.xml
@@ -61,25 +61,77 @@ limitations under the License.
         <provisionalConform/>
       </feature>
     </features>
-
-    <attribute side="server" code="0x0000" define="CURRENT_LEVEL"                 type="int8u"                isNullable="true"           writable="false" default="0x00"   optional="false">CurrentLevel</attribute>
-    <attribute side="server" code="0x0001" define="LEVEL_CONTROL_REMAINING_TIME"  type="int16u"               min="0x0000"  max="0xFFFF"  writable="false" default="0x0000" optional="true">RemainingTime</attribute>
-    <attribute side="server" code="0x0002" define="MINIMUM_LEVEL"                 type="int8u"                min="0x00"    max="0xFF"    writable="false" default="0x00"   optional="true">MinLevel</attribute>
-    <attribute side="server" code="0x0003" define="MAXIMUM_LEVEL"                 type="int8u"                min="0x00"    max="0xFF"    writable="false" default="0xFE"   optional="true">MaxLevel</attribute>
-    <attribute side="server" code="0x0004" define="CURRENT_FREQUENCY"             type="int16u"               min="0x0000"  max="0xFFFF"  writable="false" default="0x0000" optional="true">CurrentFrequency</attribute>
-    <attribute side="server" code="0x0005" define="MIN_FREQUENCY"                 type="int16u"               min="0x0000"  max="0xFFFF"  writable="false" default="0x0000" optional="true">MinFrequency</attribute>
-    <attribute side="server" code="0x0006" define="MAX_FREQUENCY"                 type="int16u"               min="0x0000"  max="0xFFFF"  writable="false" default="0x0000" optional="true">MaxFrequency</attribute>
-    
-    <attribute side="server" code="0x0010" define="ON_OFF_TRANSITION_TIME"        type="int16u"                                         writable="true"  default="0x0000"   optional="true">OnOffTransitionTime</attribute>
-    <attribute side="server" code="0x0011" define="ON_LEVEL"                      type="int8u"                isNullable="true"         writable="true"                     optional="false">OnLevel</attribute>
-    <attribute side="server" code="0x0012" define="ON_TRANSITION_TIME"            type="int16u"               isNullable="true"         writable="true"                     optional="true">OnTransitionTime</attribute>
-    <attribute side="server" code="0x0013" define="OFF_TRANSITION_TIME"           type="int16u"               isNullable="true"         writable="true"                     optional="true">OffTransitionTime</attribute>
-    <attribute side="server" code="0x0014" define="DEFAULT_MOVE_RATE"             type="int8u"                isNullable="true"   min="0x01" max="0xFF"  writable="true"    optional="true">DefaultMoveRate</attribute>
-    <attribute side="server" code="0x000F" define="OPTIONS"                       type="OptionsBitmap"        min="0x00" max="0x03"     writable="true"  default="0x00"     optional="false">Options</attribute>
-    <attribute side="server" code="0x4000" define="START_UP_CURRENT_LEVEL"        type="int8u"                isNullable="true"         writable="true"                     optional="true">
+    <attribute side="server" code="0x0000" define="CURRENT_LEVEL" type="int8u" isNullable="true">
+      <description>CurrentLevel</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="LEVEL_CONTROL_REMAINING_TIME" type="int16u" default="0x0000" optional="true">
+      <description>RemainingTime</description>
+      <mandatoryConform>
+        <feature name="LT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MINIMUM_LEVEL" type="int8u" default="0x00" optional="true">
+      <description>MinLevel</description>
+      <optionalConform>
+        <notTerm>
+          <feature name="LT"/>
+        </notTerm>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="MAXIMUM_LEVEL" type="int8u" default="0xFE" optional="true">
+      <description>MaxLevel</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0004" define="CURRENT_FREQUENCY" type="int16u" default="0x0000" optional="true" reportable="true">
+      <description>CurrentFrequency</description>
+      <mandatoryConform>
+        <feature name="FQ"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="MIN_FREQUENCY" type="int16u" default="0x0000" optional="true">
+      <description>MinFrequency</description>
+      <mandatoryConform>
+        <feature name="FQ"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="MAX_FREQUENCY" type="int16u" default="0x0000" optional="true">
+      <description>MaxFrequency</description>
+      <mandatoryConform>
+        <feature name="FQ"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0010" define="ON_OFF_TRANSITION_TIME" type="int16u" writable="true" default="0x0000" optional="true">
+      <description>OnOffTransitionTime</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0011" define="ON_LEVEL" type="int8u" isNullable="true" writable="true">
+      <description>OnLevel</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0012" define="ON_TRANSITION_TIME" type="int16u" isNullable="true" writable="true" optional="true">
+      <description>OnTransitionTime</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0013" define="OFF_TRANSITION_TIME" type="int16u" isNullable="true" writable="true" optional="true">
+      <description>OffTransitionTime</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0014" define="DEFAULT_MOVE_RATE" type="int8u" isNullable="true" min="0x01" max="0xFF" writable="true" optional="true">
+      <description>DefaultMoveRate</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x000F" define="OPTIONS" type="OptionsBitmap" min="0x00" max="0x03" writable="true" default="0x00">
+      <description>Options</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x4000" define="START_UP_CURRENT_LEVEL" type="int8u" isNullable="true" writable="true" optional="true">
       <description>StartUpCurrentLevel</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <mandatoryConform>
+        <feature name="LT"/>
+      </mandatoryConform>
     </attribute>
 
     <command source="client" code="0x00" name="MoveToLevel" optional="false" cli="zcl level-control mv-to-level">
@@ -90,6 +142,7 @@ limitations under the License.
       <arg name="TransitionTime"  type="int16u" isNullable="true"/>
       <arg name="OptionsMask"     type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x01" name="Move" optional="false" cli="zcl level-control move">
@@ -100,6 +153,7 @@ limitations under the License.
       <arg name="Rate" type="int8u" isNullable="true"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x02" name="Step" optional="false" cli="zcl level-control step">
@@ -111,6 +165,7 @@ limitations under the License.
       <arg name="TransitionTime" type="int16u" isNullable="true"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x03" name="Stop" optional="false" cli="zcl level-control stop">
@@ -119,6 +174,7 @@ limitations under the License.
       </description>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x04" name="MoveToLevelWithOnOff" optional="false" cli="zcl level-control o-mv-to-level">
@@ -129,6 +185,7 @@ limitations under the License.
       <arg name="TransitionTime"  type="int16u" isNullable="true"/>
       <arg name="OptionsMask"     type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x05" name="MoveWithOnOff" optional="false" cli="zcl level-control o-move">
@@ -139,6 +196,7 @@ limitations under the License.
       <arg name="Rate" type="int8u" isNullable="true"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x06" name="StepWithOnOff" optional="false" cli="zcl level-control o-step">
@@ -150,6 +208,7 @@ limitations under the License.
       <arg name="TransitionTime" type="int16u" isNullable="true"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x07" name="StopWithOnOff" optional="false" cli="zcl level-control o-stop">
@@ -158,6 +217,7 @@ limitations under the License.
       </description>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x08" name="MoveToClosestFrequency" optional="true">
@@ -166,6 +226,9 @@ limitations under the License.
         approximation if the exact provided one is not possible.
       </description>
       <arg name="Frequency" type="int16u"/>
+      <mandatoryConform>
+        <feature name="FQ"/>
+      </mandatoryConform>
     </command>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/localization-configuration-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/localization-configuration-cluster.xml
@@ -31,7 +31,11 @@ limitations under the License.
     <attribute side="server" code="0x00" define="ACTIVE_LOCALE" type="char_string" length="35" writable="true" optional="false">
       <description>ActiveLocale</description>
       <access op="write" privilege="manage"/>
+      <mandatoryConform/>
     </attribute>
-    <attribute side="server" code="0x01" define="SUPPORTED_LOCALES" type="array" entryType="char_string" length="254" writable="false" optional="false">SupportedLocales</attribute>
+    <attribute side="server" code="0x01" define="SUPPORTED_LOCALES" type="array" entryType="char_string" length="254">
+      <description>SupportedLocales</description>
+      <mandatoryConform/>
+    </attribute>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/low-power-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/low-power-cluster.xml
@@ -26,6 +26,7 @@ limitations under the License.
     <description>This cluster provides an interface for managing low power mode on a device.</description>
     <command source="client" code="0x00" name="Sleep" optional="false">
       <description>This command shall put the device into low power mode.</description>
+      <mandatoryConform/>
     </command>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/media-input-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/media-input-cluster.xml
@@ -32,20 +32,29 @@ limitations under the License.
       </feature>
     </features>
 
-    <attribute side="server" code="0x0000" define="MEDIA_INPUT_LIST"          type="array" entryType="InputInfoStruct" length="254"           writable="false" optional="false">InputList</attribute>
-    <attribute side="server" code="0x0001" define="MEDIA_INPUT_CURRENT_INPUT" type="int8u" default="0x00"              min="0x00" max="0xFF"  writable="false" optional="false">CurrentInput</attribute>
+    <attribute side="server" code="0x0000" define="MEDIA_INPUT_LIST" type="array" entryType="InputInfoStruct" length="254">
+      <description>InputList</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MEDIA_INPUT_CURRENT_INPUT" type="int8u">
+      <description>CurrentInput</description>
+      <mandatoryConform/>
+    </attribute>
 
     <command source="client" code="0x00" name="SelectInput" optional="false">
       <description>Upon receipt, this SHALL change the input on the media device to the input at a specific index in the Input List.</description>
       <arg name="Index" type="int8u"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x01" name="ShowInputStatus" optional="false">
       <description>Upon receipt, this SHALL display the active status of the input list on screen.</description>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x02" name="HideInputStatus" optional="false">
       <description>Upon receipt, this SHALL hide the input list from the screen.</description>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x03" name="RenameInput" optional="true">
@@ -53,6 +62,9 @@ limitations under the License.
       <access op="invoke" privilege="manage"/>
       <arg name="Index" type="int8u"/>
       <arg name="Name" type="char_string"/>
+      <mandatoryConform>
+        <feature name="NU"/>
+      </mandatoryConform>
     </command>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/media-playback-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/media-playback-cluster.xml
@@ -46,87 +46,167 @@ limitations under the License.
       </feature>
     </features>
 
-    <attribute side="server" code="0x0000" define="MEDIA_PLAYBACK_STATE"                     type="PlaybackStateEnum" min="0x00" max="0x03" default="0x00" writable="false"                    optional="false">CurrentState</attribute>
-    <attribute side="server" code="0x0001" define="MEDIA_PLAYBACK_START_TIME"                type="epoch_us"          min="0x00"            default="0x00" writable="false" isNullable="true"  optional="true">StartTime</attribute>
-    <attribute side="server" code="0x0002" define="MEDIA_PLAYBACK_DURATION"                  type="int64u"            min="0x00"            default="0"    writable="false" isNullable="true"  optional="true">Duration</attribute>
-    <attribute side="server" code="0x0003" define="MEDIA_PLAYBACK_PLAYBACK_POSITION"         type="PlaybackPositionStruct"                                 writable="false" isNullable="true"  optional="true">SampledPosition</attribute>
-    <attribute side="server" code="0x0004" define="MEDIA_PLAYBACK_PLAYBACK_SPEED"            type="single"            min="0x00"            default="0"    writable="false"                    optional="true">PlaybackSpeed</attribute>
-    <attribute side="server" code="0x0005" define="MEDIA_PLAYBACK_PLAYBACK_SEEK_RANGE_END"   type="int64u"            min="0x00"                           writable="false" isNullable="true"  optional="true">SeekRangeEnd</attribute>
-    <attribute side="server" code="0x0006" define="MEDIA_PLAYBACK_PLAYBACK_SEEK_RANGE_START" type="int64u"            min="0x00"                           writable="false" isNullable="true"  optional="true">SeekRangeStart</attribute>
-    <attribute side="server" code="0x0007" define="MEDIA_PLAYBACK_PLAYBACK_ACTIVE_AUDIO_TRACK" optional="true"      type="TrackStruct"     writable="false" isNullable="true">ActiveAudioTrack</attribute>
-    <attribute side="server" code="0x0008" define="MEDIA_PLAYBACK_PLAYBACK_AVAILABLE_AUDIO_TRACKS" optional="true"  type="array" entryType="TrackStruct"     writable="false" isNullable="true">AvailableAudioTracks</attribute>
-    <attribute side="server" code="0x0009" define="MEDIA_PLAYBACK_PLAYBACK_ACTIVE_TEXT_TRACK" optional="true"      type="TrackStruct"     writable="false" isNullable="true">ActiveTextTrack</attribute>
-    <attribute side="server" code="0x000A" define="MEDIA_PLAYBACK_PLAYBACK_AVAILABLE_TEXT_TRACKS" optional="true"  type="array" entryType="TrackStruct"     writable="false" isNullable="true">AvailableTextTracks</attribute>
+    <attribute side="server" code="0x0000" define="MEDIA_PLAYBACK_STATE" type="PlaybackStateEnum" min="0x00" max="0x03">
+      <description>CurrentState</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MEDIA_PLAYBACK_START_TIME" type="epoch_us" isNullable="true" optional="true">
+      <description>StartTime</description>
+      <mandatoryConform>
+        <feature name="AS"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MEDIA_PLAYBACK_DURATION" type="int64u" isNullable="true" optional="true">
+      <description>Duration</description>
+      <mandatoryConform>
+        <feature name="AS"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="MEDIA_PLAYBACK_PLAYBACK_POSITION" type="PlaybackPositionStruct" isNullable="true" optional="true">
+      <description>SampledPosition</description>
+      <mandatoryConform>
+        <feature name="AS"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="MEDIA_PLAYBACK_PLAYBACK_SPEED" type="single" default="0" optional="true">
+      <description>PlaybackSpeed</description>
+      <mandatoryConform>
+        <feature name="AS"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="MEDIA_PLAYBACK_PLAYBACK_SEEK_RANGE_END" type="int64u" isNullable="true" optional="true">
+      <description>SeekRangeEnd</description>
+      <mandatoryConform>
+        <feature name="AS"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="MEDIA_PLAYBACK_PLAYBACK_SEEK_RANGE_START" type="int64u" isNullable="true" optional="true">
+      <description>SeekRangeStart</description>
+      <mandatoryConform>
+        <feature name="AS"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="MEDIA_PLAYBACK_PLAYBACK_ACTIVE_AUDIO_TRACK" optional="true" type="TrackStruct" isNullable="true">
+      <description>ActiveAudioTrack</description>
+      <mandatoryConform>
+        <feature name="AT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="MEDIA_PLAYBACK_PLAYBACK_AVAILABLE_AUDIO_TRACKS" optional="true" type="array" entryType="TrackStruct" isNullable="true">
+      <description>AvailableAudioTracks</description>
+      <mandatoryConform>
+        <feature name="AT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="MEDIA_PLAYBACK_PLAYBACK_ACTIVE_TEXT_TRACK" optional="true" type="TrackStruct" isNullable="true">
+      <description>ActiveTextTrack</description>
+      <mandatoryConform>
+        <feature name="TT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x000A" define="MEDIA_PLAYBACK_PLAYBACK_AVAILABLE_TEXT_TRACKS" optional="true" type="array" entryType="TrackStruct" isNullable="true">
+      <description>AvailableTextTracks</description>
+      <mandatoryConform>
+        <feature name="TT"/>
+      </mandatoryConform>
+    </attribute>
 
 
     <command source="client" code="0x00" name="Play" response="PlaybackResponse" optional="false">
       <description>Upon receipt, this SHALL play media.</description>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x01" name="Pause" response="PlaybackResponse" optional="false">
       <description>Upon receipt, this SHALL pause media.</description>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x02" name="Stop" response="PlaybackResponse" optional="false">
       <description>Upon receipt, this SHALL stop media. User experience is context-specific. This will often navigate the user back to the location where media was originally launched.</description>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x03" name="StartOver" response="PlaybackResponse" optional="true">
       <description>Upon receipt, this SHALL Start Over with the current media playback item.</description>
+      <optionalConform/>
     </command>
 
     <command source="client" code="0x04" name="Previous" response="PlaybackResponse" optional="true">
       <description>Upon receipt, this SHALL cause the handler to be invoked for "Previous". User experience is context-specific. This will often Go back to the previous media playback item.</description>
+      <optionalConform/>
     </command>
 
     <command source="client" code="0x05" name="Next" response="PlaybackResponse" optional="true">
       <description>Upon receipt, this SHALL cause the handler to be invoked for "Next". User experience is context-specific. This will often Go forward to the next media playback item.</description>
+      <optionalConform/>
     </command>
 
     <command source="client" code="0x06" name="Rewind" response="PlaybackResponse" optional="true">
       <description>Upon receipt, this SHALL Rewind through media. Different Rewind speeds can be used on the TV based upon the number of sequential calls to this function. This is to avoid needing to define every speed now (multiple fast, slow motion, etc).</description>
       <arg name="AudioAdvanceUnmuted" type="boolean" optional="true"/>
+      <mandatoryConform>
+        <feature name="VS"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x07" name="FastForward" response="PlaybackResponse" optional="true">
       <description>Upon receipt, this SHALL Advance through media. Different FF speeds can be used on the TV based upon the number of sequential calls to this function. This is to avoid needing to define every speed now (multiple fast, slow motion, etc).</description>
       <arg name="AudioAdvanceUnmuted" type="boolean" optional="true"/>
+      <mandatoryConform>
+        <feature name="VS"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x08" name="SkipForward" response="PlaybackResponse" optional="true">
       <description>Upon receipt, this SHALL Skip forward in the media by the given number of seconds, using the data as follows:</description>
       <arg name="DeltaPositionMilliseconds" type="int64u"/>
+      <optionalConform/>
     </command>
 
     <command source="client" code="0x09" name="SkipBackward" response="PlaybackResponse" optional="true">
       <description>Upon receipt, this SHALL Skip backward in the media by the given number of seconds, using the data as follows:</description>
       <arg name="DeltaPositionMilliseconds" type="int64u"/>
+      <optionalConform/>
     </command>
 
     <command source="client" code="0x0B" name="Seek" response="PlaybackResponse" optional="true">
       <description>Upon receipt, this SHALL Skip backward in the media by the given number of seconds, using the data as follows:</description>
       <arg name="position" type="int64u"/>
+      <mandatoryConform>
+        <feature name="AS"/>
+      </mandatoryConform>
     </command>
 
     <command source="server" code="0x0A" name="PlaybackResponse" optional="false">
       <description>This command SHALL be generated in response to various Playback Request commands.</description>
       <arg name="Status" type="StatusEnum"/>
       <arg name="Data"   type="char_string" optional="true"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x0C" name="ActivateAudioTrack" optional="true">
       <description>Upon receipt, the server SHALL set the active Audio Track to the one identified by the TrackID in the Track catalog for the streaming media. If the TrackID does not exist in the Track catalog, OR does not correspond to the streaming media OR no media is being streamed at the time of receipt of this command, the server will return an error status of INVALID_ARGUMENT.</description>
       <arg name="TrackID" type="CHAR_STRING"/>
       <arg name="AudioOutputIndex"   type="INT8U"/>
+      <mandatoryConform>
+        <feature name="AT"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x0D" name="ActivateTextTrack" optional="true">
       <description>Upon receipt, the server SHALL set the active Text Track to the one identified by the TrackID in the Track catalog for the streaming media. If the TrackID does not exist in the Track catalog, OR does not correspond to the streaming media OR no media is being streamed at the time of receipt of this command, the server SHALL return an error status of INVALID_ARGUMENT.</description>
       <arg name="TrackID" type="CHAR_STRING"/>
+      <mandatoryConform>
+        <feature name="TT"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x0E" name="DeactivateTextTrack" optional="true">
       <description>If a Text Track is active (i.e. being displayed), upon receipt of this command, the server SHALL stop displaying it.</description>
+      <mandatoryConform>
+        <feature name="TT"/>
+      </mandatoryConform>
     </command>
 
     <event side="server" code="0x00" priority="info" name="StateChanged" optional="true">
@@ -140,6 +220,7 @@ limitations under the License.
       <field id="6" name="SeekRangeStart" type="INT64U"/>
       <field id="7" name="Data" type="OCTET_STRING" optional="true" length="900" />
       <field id="8" name="AudioAdvanceUnmuted" type="boolean" default="true"/>
+      <optionalConform/>
     </event>
   </cluster>
 

--- a/src/app/zap-templates/zcl/data-model/chip/messages-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/messages-cluster.xml
@@ -91,8 +91,14 @@ limitations under the License.
       </feature>
     </features>
 
-    <attribute side="server" code="0x0000" define="LIST_MESSAGES" type="array" entryType="MessageStruct" length="8" writable="false" optional="false">Messages</attribute>
-    <attribute side="server" code="0x0001" define="MESSAGES_CLUSTER_ACTIVE_MESSAGES_IDS" type="ARRAY" entryType="octet_string" max="8" writable="false" optional="false">ActiveMessageIDs</attribute>
+    <attribute side="server" code="0x0000" define="LIST_MESSAGES" type="array" entryType="MessageStruct" length="8">
+      <description>Messages</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MESSAGES_CLUSTER_ACTIVE_MESSAGES_IDS" type="ARRAY" entryType="octet_string" max="8">
+      <description>ActiveMessageIDs</description>
+      <mandatoryConform/>
+    </attribute>
     <command source="client" code="0x00" name="PresentMessagesRequest" isFabricScoped="true" optional="false">
       <description>
         Command for requesting messages be presented
@@ -104,20 +110,24 @@ limitations under the License.
       <arg name="Duration" type="int64u" default="0" optional="false" isNullable="true"/>
       <arg name="MessageText" type="char_string" length="256" optional="false"/>
       <arg name="Responses" type="MessageResponseOptionStruct" array="true" length="4" optional="true"/>
+      <mandatoryConform/>
     </command>
     <command source="client" code="0x01" name="CancelMessagesRequest" isFabricScoped="true" optional="false">
       <description>
         Command for cancelling message present requests
       </description>
       <arg name="MessageIDs" type="octet_string" array="true" optional="false"/>
+      <mandatoryConform/>
     </command>
     <event side="server" code="0x00" name="MessageQueued" priority="info" optional="false">
       <description>This event SHALL be generated when the message is confirmed by the user, or when the expiration date of the message is reached.</description>
       <field id="0" name="MessageID" type="octet_string" max="16"/>
+      <mandatoryConform/>
     </event>
     <event side="server" code="0x01" name="MessagePresented" priority="info" optional="false">
       <description>This event SHALL be generated when the message is presented to the user.</description>
       <field id="0" name="MessageID" type="octet_string" max="16"/>
+      <mandatoryConform/>
     </event>
     <event side="server" code="0x02" name="MessageComplete" priority="info" optional="false">
       <description>This event SHALL be generated when the message is confirmed by the user, or when the expiration date of the message is reached.</description>
@@ -125,6 +135,7 @@ limitations under the License.
       <field id="1" name="ResponseID" type="int32u" isNullable="true" optional="true"/>
       <field id="2" name="Reply" type="char_string" length="256" isNullable="true" optional="true"/>
       <field id="3" name="FutureMessagesPreference" type="FutureMessagePreferenceEnum" isNullable="true" optional="false"/>
+      <mandatoryConform/>
     </event>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/microwave-oven-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/microwave-oven-control-cluster.xml
@@ -41,27 +41,74 @@ limitations under the License.
       </feature>
     </features>
 
-    <attribute side="server" code="0x0000" define="COOK_TIME"           type="elapsed_s" default="30"  writable="false" optional="false">CookTime</attribute>
-    <attribute side="server" code="0x0001" define="MAX_COOK_TIME"       type="elapsed_s"               writable="false" optional="false" min="1" max="86400">MaxCookTime</attribute>
-    <attribute side="server" code="0x0002" define="POWER_SETTING"       type="int8u"     default="100" writable="false" optional="true">PowerSetting</attribute>
-    <attribute side="server" code="0x0003" define="MIN_POWER"           type="int8u"     default="10"  writable="false" optional="true">MinPower</attribute>
-    <attribute side="server" code="0x0004" define="MAX_POWER"           type="int8u"     default="100" writable="false" optional="true">MaxPower</attribute>
-    <attribute side="server" code="0x0005" define="POWER_STEP"          type="int8u"     default="10"  writable="false" optional="true">PowerStep</attribute>
-    <attribute apiMaturity="provisional" side="server" code="0x0006" define="SUPPORTED_WATTS"     type="array" entryType="int16u" writable="false" optional="true">SupportedWatts</attribute>
-    <attribute apiMaturity="provisional" side="server" code="0x0007" define="SELECTED_WATT_INDEX" type="int8u"                   writable="false" optional="true">SelectedWattIndex</attribute>
-    <attribute side="server" code="0x0008" define="WATT_RATING"         type="int16u"                  writable="false" optional="true">WattRating</attribute>
-
+    <attribute side="server" code="0x0000" define="COOK_TIME" type="elapsed_s" default="30">
+      <description>CookTime</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MAX_COOK_TIME" type="elapsed_s" min="1" max="86400">
+      <description>MaxCookTime</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="POWER_SETTING" type="int8u" default="100" optional="true">
+      <description>PowerSetting</description>
+      <mandatoryConform>
+        <feature name="PWRNUM"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="MIN_POWER" type="int8u" default="10" optional="true">
+      <description>MinPower</description>
+      <mandatoryConform>
+        <feature name="PWRLMTS"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="MAX_POWER" type="int8u" default="100" optional="true">
+      <description>MaxPower</description>
+      <mandatoryConform>
+        <feature name="PWRLMTS"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="POWER_STEP" type="int8u" default="10" optional="true">
+      <description>PowerStep</description>
+      <mandatoryConform>
+        <feature name="PWRLMTS"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute apiMaturity="provisional" side="server" code="0x0006" define="SUPPORTED_WATTS" type="array" entryType="int16u" optional="true">
+      <description>SupportedWatts</description>
+      <otherwiseConform>
+        <provisionalConform/>
+        <mandatoryConform>
+          <feature name="WATTS"/>
+        </mandatoryConform>
+      </otherwiseConform>
+    </attribute>
+    <attribute apiMaturity="provisional" side="server" code="0x0007" define="SELECTED_WATT_INDEX" type="int8u" optional="true">
+      <description>SelectedWattIndex</description>
+      <otherwiseConform>
+        <provisionalConform/>
+        <mandatoryConform>
+          <feature name="WATTS"/>
+        </mandatoryConform>
+      </otherwiseConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="WATT_RATING" type="int16u" optional="true">
+      <description>WattRating</description>
+      <optionalConform/>
+    </attribute>
+    
     <command source="client" code="0x00" name="SetCookingParameters" optional="false">
-        <description>Set Cooking Parameters</description>
+      <description>Set Cooking Parameters</description>
         <arg name="CookMode"          type="int8u"     optional="true"/>
         <arg name="CookTime"          type="elapsed_s" optional="true"/>
         <arg name="PowerSetting"      type="int8u" min="MIN_POWER" max="MAX_POWER" optional="true"/>
         <arg name="WattSettingIndex"  type="int8u"     optional="true"/>
         <arg name="StartAfterSetting" type="boolean"   optional="true"/>
+      <mandatoryConform/>
     </command>
     <command source="client" code="0x01" name="AddMoreTime" optional="true">
-        <description>Add More Cooking Time</description>
-        <arg name="TimeToAdd" type="elapsed_s" optional="false"/>
+      <description>Add More Cooking Time</description>
+      <arg name="TimeToAdd" type="elapsed_s" optional="false"/>
+      <optionalConform/>
     </command>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/microwave-oven-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/microwave-oven-mode-cluster.xml
@@ -55,7 +55,13 @@ limitations under the License.
     </features>
 
     <!-- Base data types -->
-    <attribute side="server" code="0x0000" define="SUPPORTED_MODES"  type="array" entryType="ModeOptionStruct" writable="false" optional="false" isNullable="false" length="255">SupportedModes</attribute>
-    <attribute side="server" code="0x0001" define="CURRENT_MODE"     type="int8u"                              writable="false" optional="false" isNullable="false" reportable="true">CurrentMode</attribute>
+    <attribute side="server" code="0x0000" define="SUPPORTED_MODES" type="array" entryType="ModeOptionStruct" length="255">
+      <description>SupportedModes</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="CURRENT_MODE" type="int8u" reportable="true">
+      <description>CurrentMode</description>
+      <mandatoryConform/>
+    </attribute>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/mode-select-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/mode-select-cluster.xml
@@ -48,19 +48,39 @@ limitations under the License.
 
     <description>Attributes and commands for selecting a mode from a list of supported options.</description>
     <!-- Base data types -->
-    <attribute side="server" code="0x0000" define="MODE_DESCRIPTION"   type="char_string"                        length="64"  writable="false" optional="false" isNullable="false">Description</attribute>
-    <attribute side="server" code="0x0001" define="STANDARD_NAMESPACE" type="enum16"                                          writable="false" optional="false" isNullable="true">StandardNamespace</attribute>
-    <attribute side="server" code="0x0002" define="SUPPORTED_MODES"    type="array" entryType="ModeOptionStruct" length="255" writable="false" optional="false" isNullable="false">SupportedModes</attribute>
-    <attribute side="server" code="0x0003" define="CURRENT_MODE"       type="int8u"                                           writable="false" optional="false" isNullable="false" reportable="true">CurrentMode</attribute>
-    <attribute side="server" code="0x0004" define="START_UP_MODE"      type="int8u"                                           writable="true"  optional="true"  isNullable="true">StartUpMode</attribute>
-    <attribute side="server" code="0x0005" define="ON_MODE"            type="int8u"                                           writable="true"  optional="true"  isNullable="true">OnMode</attribute>
-
+    <attribute side="server" code="0x0000" define="MODE_DESCRIPTION" type="char_string" length="64">
+      <description>Description</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="STANDARD_NAMESPACE" type="enum16" isNullable="true">
+      <description>StandardNamespace</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="SUPPORTED_MODES" type="array" entryType="ModeOptionStruct" length="255">
+      <description>SupportedModes</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="CURRENT_MODE" type="int8u" reportable="true">
+      <description>CurrentMode</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0004" define="START_UP_MODE" type="int8u" writable="true" optional="true" isNullable="true">
+      <description>StartUpMode</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0005" define="ON_MODE" type="int8u" writable="true" optional="true" isNullable="true">
+      <description>OnMode</description>
+      <mandatoryConform>
+        <feature name="DEPONOFF"/>
+      </mandatoryConform>
+    </attribute>
     <!-- Test Commands -->
     <command source="client" code="0x00" name="ChangeToMode" optional="false">
       <description>
         On receipt of this command, if the NewMode field matches the Mode field in an entry of the SupportedModes list, the server SHALL set the CurrentMode attribute to the NewMode value, otherwise, the server SHALL respond with an INVALID_COMMAND status response.
       </description>
       <arg name="NewMode" type="int8u" />
+      <mandatoryConform/>
     </command>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/network-commissioning-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/network-commissioning-cluster.xml
@@ -107,120 +107,207 @@ limitations under the License.
             <feature bit="2" code="ET" name="EthernetNetworkInterface" summary="Ethernet related features">
             <optionalConform choice="a"/>
             </feature>
-            <feature bit="3" code="PC" name="PerDeviceCredentials" summary="Device related features">
-            <optionalConform choice="a"/>
+            <feature bit="3" code="PDC" name="PerDeviceCredentials" summary="Wi-Fi Per-Device Credentials">
+            <mandatoryConform>
+              <feature name="WI"/>
+            </mandatoryConform>
             </feature>
         </features>
 
-        <attribute side="server" code="0x0000" define="MAX_NETWORKS" type="int8u" writable="false" optional="false">
+        <attribute side="server" code="0x0000" define="MAX_NETWORKS" type="int8u">
             <description>MaxNetworks</description>
             <access op="read" privilege="administer"/>
+            <mandatoryConform/>
         </attribute>
-        <attribute side="server" code="0x0001" define="NETWORKS" type="array" entryType="NetworkInfoStruct" writable="false" optional="false">
+        <attribute side="server" code="0x0001" define="NETWORKS" type="array" entryType="NetworkInfoStruct">
             <description>Networks</description>
             <access op="read" privilege="administer"/>
+            <mandatoryConform/>
         </attribute>
-        <attribute side="server" code="0x0002" define="SCAN_MAX_TIME_SECONDS" type="int8u" writable="false" optional="true">ScanMaxTimeSeconds</attribute>
-        <attribute side="server" code="0x0003" define="CONNECT_MAX_TIME_SECONDS" type="int8u" writable="false" optional="true">ConnectMaxTimeSeconds</attribute>
-        <attribute side="server" code="0x0004" define="INTERFACE_ENABLED" type="boolean" writable="true" optional="false">
+        <attribute side="server" code="0x0002" define="SCAN_MAX_TIME_SECONDS" type="int8u" optional="true">
+            <description>ScanMaxTimeSeconds</description>
+            <mandatoryConform>
+              <orTerm>
+                <feature name="WI"/>
+                <feature name="TH"/>
+              </orTerm>
+            </mandatoryConform>
+        </attribute>
+        <attribute side="server" code="0x0003" define="CONNECT_MAX_TIME_SECONDS" type="int8u" optional="true">
+            <description>ConnectMaxTimeSeconds</description>
+            <mandatoryConform>
+              <orTerm>
+                <feature name="WI"/>
+                <feature name="TH"/>
+              </orTerm>
+            </mandatoryConform>
+          </attribute>
+        <attribute side="server" code="0x0004" define="INTERFACE_ENABLED" type="boolean" writable="true">
             <description>InterfaceEnabled</description>
             <access op="read" privilege="view"/>
             <access op="write" privilege="administer"/>
+            <mandatoryConform/>
         </attribute>
-        <attribute side="server" code="0x0005" define="LAST_NETWORKING_STATUS" type="NetworkCommissioningStatusEnum" writable="false" optional="false" isNullable="true">
+        <attribute side="server" code="0x0005" define="LAST_NETWORKING_STATUS" type="NetworkCommissioningStatusEnum" isNullable="true">
             <description>LastNetworkingStatus</description>
             <access op="read" privilege="administer"/>
+            <mandatoryConform/>
         </attribute>
-        <attribute side="server" code="0x0006" define="LAST_NETWORK_ID" type="octet_string" length="32" writable="false" optional="false" isNullable="true">
+        <attribute side="server" code="0x0006" define="LAST_NETWORK_ID" type="octet_string" length="32" isNullable="true">
             <description>LastNetworkID</description>
             <access op="read" privilege="administer"/>
+            <mandatoryConform/>
         </attribute>
-        <attribute side="server" code="0x0007" define="LAST_CONNECT_ERROR_VALUE" type="int32s" writable="false" optional="false" isNullable="true">
+        <attribute side="server" code="0x0007" define="LAST_CONNECT_ERROR_VALUE" type="int32s" isNullable="true">
             <description>LastConnectErrorValue</description>
             <access op="read" privilege="administer"/>
+            <mandatoryConform/>
         </attribute>
-        <attribute side="server" code="0x0008" define="SUPPORTED_WIFI_BANDS" type="array" entryType="WiFiBandEnum" writable="false" optional="true" apiMaturity="provisional">
+        <attribute side="server" code="0x0008" define="SUPPORTED_WIFI_BANDS" type="array" entryType="WiFiBandEnum" optional="true" apiMaturity="provisional">
           <description>SupportedWiFiBands</description>
+          <mandatoryConform>
+            <feature name="WI"/>
+          </mandatoryConform>
         </attribute>
-        <attribute side="server" code="0x0009" define="SUPPORTED_THREAD_FEATURES" type="ThreadCapabilitiesBitmap" writable="false" optional="true" apiMaturity="provisional">
+        <attribute side="server" code="0x0009" define="SUPPORTED_THREAD_FEATURES" type="ThreadCapabilitiesBitmap" optional="true" apiMaturity="provisional">
           <description>SupportedThreadFeatures</description>
+          <mandatoryConform>
+            <feature name="TH"/>
+          </mandatoryConform>
         </attribute>
-        <attribute side="server" code="0x000A" define="THREAD_VERSION" type="int16u" writable="false" optional="true" apiMaturity="provisional">
+        <attribute side="server" code="0x000A" define="THREAD_VERSION" type="int16u" optional="true" apiMaturity="provisional">
           <description>ThreadVersion</description>
+          <mandatoryConform>
+            <feature name="TH"/>
+          </mandatoryConform>
         </attribute>
 
-        <command source="client" code="0x00" name="ScanNetworks" optional="true" response="ScanNetworksResponse" cli="chip network_commissioning scannetworks">
-            <description>Detemine the set of networks the device sees as available.</description>
-            <arg name="SSID" type="octet_string" length="32" isNullable="true" optional="true"/>
-            <arg name="Breadcrumb" type="int64u" optional="true"/>
-            <access op="invoke" privilege="administer"/>
-        </command>
-        <command source="server" code="0x01" name="ScanNetworksResponse" optional="true" cli="chip network_commissioning scannetworksresponse">
-            <description>Relay the set of networks the device sees as available back to the client.</description>
-            <arg name="NetworkingStatus" type="NetworkCommissioningStatusEnum"/>
-            <arg name="DebugText" type="char_string" optional="true"/>
-            <arg name="WiFiScanResults" type="WiFiInterfaceScanResultStruct" array="true" optional="true"/>
-            <arg name="ThreadScanResults" type="ThreadInterfaceScanResultStruct" array="true" optional="true"/>
-        </command>
-        <command source="client" code="0x02" name="AddOrUpdateWiFiNetwork" optional="true" response="NetworkConfigResponse" cli="chip network_commissioning addorupdatewifinetwork">
-            <description>Add or update the credentials for a given Wi-Fi network.</description>
-            <arg name="SSID" type="octet_string" length="32"/>
-            <arg name="Credentials" type="octet_string" length="64"/>
-            <arg name="Breadcrumb" type="int64u" optional="true"/>
-            <arg name="NetworkIdentity" type="octet_string" length="140" optional="true"/>
-            <arg name="ClientIdentifier" type="octet_string" length="20" optional="true"/>
-            <arg name="PossessionNonce" type="octet_string" length="32" optional="true"/>
-            <access op="invoke" privilege="administer"/>
-        </command>
-        <command source="client" code="0x03" name="AddOrUpdateThreadNetwork" optional="true" response="NetworkConfigResponse" cli="chip network_commissioning addorupdatethreadnetwork">
-            <description>Add or update the credentials for a given Thread network.</description>
-            <arg name="OperationalDataset" type="octet_string" length="254"/>
-            <arg name="Breadcrumb" type="int64u" optional="true"/>
-            <access op="invoke" privilege="administer"/>
-        </command>
-        <command source="client" code="0x04" name="RemoveNetwork" optional="true" response="NetworkConfigResponse" cli="chip network_commissioning removenetwork">
-            <description>Remove the definition of a given network (including its credentials).</description>
-            <arg name="NetworkID" type="octet_string" length="32"/>
-            <arg name="Breadcrumb" type="int64u" optional="true"/>
-            <access op="invoke" privilege="administer"/>
-        </command>
-        <command source="server" code="0x05" name="NetworkConfigResponse" optional="true" cli="chip network_commissioning addwifiresponse">
-            <description>Response command for various commands that add/remove/modify network credentials.</description>
-            <arg name="NetworkingStatus" type="NetworkCommissioningStatusEnum"/>
-            <arg name="DebugText" type="char_string" length="512" optional="true" />
-            <arg name="NetworkIndex" type="int8u" optional="true" />
-            <arg name="ClientIdentity" type="octet_string" length="140" optional="true"/>
-            <arg name="PossessionSignature" type="octet_string" length="64" optional="true"/>
-        </command>
-        <command source="client" code="0x06" name="ConnectNetwork" optional="true" response="ConnectNetworkResponse" cli="chip network_commissioning connectnetwork">
-            <description>Connect to the specified network, using previously-defined credentials.</description>
-            <arg name="NetworkID" type="octet_string" length="32"/>
-            <arg name="Breadcrumb" type="int64u" optional="true"/>
-            <access op="invoke" privilege="administer"/>
-        </command>
-        <command source="server" code="0x07" name="ConnectNetworkResponse" optional="true" cli="chip network_commissioning connectnetworkresponse">
-            <description>Command that indicates whether we have succcessfully connected to a network.</description>
-            <arg name="NetworkingStatus" type="NetworkCommissioningStatusEnum"/>
-            <arg name="DebugText" type="char_string" optional="true"/>
-            <arg name="ErrorValue" type="int32s" isNullable="true"/>
-        </command>
-        <command source="client" code="0x08" name="ReorderNetwork" optional="true" response="NetworkConfigResponse" cli="chip network_commissioning connectnetwork">
-            <description>Modify the order in which networks will be presented in the Networks attribute.</description>
-            <arg name="NetworkID" type="octet_string" length="32"/>
-            <arg name="NetworkIndex" type="int8u"/>
-            <arg name="Breadcrumb" type="int64u" optional="true"/>
-            <access op="invoke" privilege="administer"/>
-        </command>
-        <command source="client" code="0x09" name="QueryIdentity" optional="true" response="QueryIdentityResponse" cli="chip network_commissioning queryidentity">
-            <description>Retrieve details about and optionally proof of possession of a network client identity.</description>
-            <arg name="KeyIdentifier" type="octet_string" length="20"/>
-            <arg name="PossessionNonce" type="octet_string" length="32" optional="true"/>
-            <access op="invoke" privilege="administer"/>
-        </command>
-        <command source="server" code="0x0a" name="QueryIdentityResponse" optional="true">
-            <description>Command that contains details about a network client identity and optionally a proof of possession.</description>
-            <arg name="Identity" type="octet_string" length="140"/>
-            <arg name="PossessionSignature" type="octet_string" length="64" optional="true"/>
-        </command>
-    </cluster>
+    <command source="client" code="0x00" name="ScanNetworks" optional="true" response="ScanNetworksResponse" cli="chip network_commissioning scannetworks">
+      <description>Detemine the set of networks the device sees as available.</description>
+      <arg name="SSID" type="octet_string" length="32" isNullable="true" optional="true"/>
+      <arg name="Breadcrumb" type="int64u" optional="true"/>
+      <access op="invoke" privilege="administer"/>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="WI"/>
+          <feature name="TH"/>
+        </orTerm>
+      </mandatoryConform>
+    </command>
+    <command source="server" code="0x01" name="ScanNetworksResponse" optional="true" cli="chip network_commissioning scannetworksresponse">
+      <description>Relay the set of networks the device sees as available back to the client.</description>
+      <arg name="NetworkingStatus" type="NetworkCommissioningStatusEnum"/>
+      <arg name="DebugText" type="char_string" optional="true"/>
+      <arg name="WiFiScanResults" type="WiFiInterfaceScanResultStruct" array="true" optional="true"/>
+      <arg name="ThreadScanResults" type="ThreadInterfaceScanResultStruct" array="true" optional="true"/>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="WI"/>
+          <feature name="TH"/>
+        </orTerm>
+      </mandatoryConform>
+    </command>
+    <command source="client" code="0x02" name="AddOrUpdateWiFiNetwork" optional="true" response="NetworkConfigResponse" cli="chip network_commissioning addorupdatewifinetwork">
+      <description>Add or update the credentials for a given Wi-Fi network.</description>
+      <arg name="SSID" type="octet_string" length="32"/>
+      <arg name="Credentials" type="octet_string" length="64"/>
+      <arg name="Breadcrumb" type="int64u" optional="true"/>
+      <arg name="NetworkIdentity" type="octet_string" length="140" optional="true"/>
+      <arg name="ClientIdentifier" type="octet_string" length="20" optional="true"/>
+      <arg name="PossessionNonce" type="octet_string" length="32" optional="true"/>
+      <access op="invoke" privilege="administer"/>
+      <mandatoryConform>
+        <feature name="WI"/>
+      </mandatoryConform>
+    </command>
+    <command source="client" code="0x03" name="AddOrUpdateThreadNetwork" optional="true" response="NetworkConfigResponse" cli="chip network_commissioning addorupdatethreadnetwork">
+      <description>Add or update the credentials for a given Thread network.</description>
+      <arg name="OperationalDataset" type="octet_string" length="254"/>
+      <arg name="Breadcrumb" type="int64u" optional="true"/>
+      <access op="invoke" privilege="administer"/>
+      <mandatoryConform>
+        <feature name="TH"/>
+      </mandatoryConform>
+    </command>
+    <command source="client" code="0x04" name="RemoveNetwork" optional="true" response="NetworkConfigResponse" cli="chip network_commissioning removenetwork">
+      <description>Remove the definition of a given network (including its credentials).</description>
+      <arg name="NetworkID" type="octet_string" length="32"/>
+      <arg name="Breadcrumb" type="int64u" optional="true"/>
+      <access op="invoke" privilege="administer"/>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="WI"/>
+          <feature name="TH"/>
+        </orTerm>
+      </mandatoryConform>
+    </command>
+    <command source="server" code="0x05" name="NetworkConfigResponse" optional="true" cli="chip network_commissioning addwifiresponse">
+      <description>Response command for various commands that add/remove/modify network credentials.</description>
+      <arg name="NetworkingStatus" type="NetworkCommissioningStatusEnum"/>
+      <arg name="DebugText" type="char_string" length="512" optional="true" />
+      <arg name="NetworkIndex" type="int8u" optional="true" />
+      <arg name="ClientIdentity" type="octet_string" length="140" optional="true"/>
+      <arg name="PossessionSignature" type="octet_string" length="64" optional="true"/>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="WI"/>
+          <feature name="TH"/>
+        </orTerm>
+      </mandatoryConform>
+    </command>
+    <command source="client" code="0x06" name="ConnectNetwork" optional="true" response="ConnectNetworkResponse" cli="chip network_commissioning connectnetwork">
+      <description>Connect to the specified network, using previously-defined credentials.</description>
+      <arg name="NetworkID" type="octet_string" length="32"/>
+      <arg name="Breadcrumb" type="int64u" optional="true"/>
+      <access op="invoke" privilege="administer"/>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="WI"/>
+          <feature name="TH"/>
+        </orTerm>
+      </mandatoryConform>
+    </command>
+    <command source="server" code="0x07" name="ConnectNetworkResponse" optional="true" cli="chip network_commissioning connectnetworkresponse">
+      <description>Command that indicates whether we have succcessfully connected to a network.</description>
+      <arg name="NetworkingStatus" type="NetworkCommissioningStatusEnum"/>
+      <arg name="DebugText" type="char_string" optional="true"/>
+      <arg name="ErrorValue" type="int32s" isNullable="true"/>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="WI"/>
+          <feature name="TH"/>
+        </orTerm>
+      </mandatoryConform>
+    </command>
+    <command source="client" code="0x08" name="ReorderNetwork" optional="true" response="NetworkConfigResponse" cli="chip network_commissioning connectnetwork">
+      <description>Modify the order in which networks will be presented in the Networks attribute.</description>
+      <arg name="NetworkID" type="octet_string" length="32"/>
+      <arg name="NetworkIndex" type="int8u"/>
+      <arg name="Breadcrumb" type="int64u" optional="true"/>
+      <access op="invoke" privilege="administer"/>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="WI"/>
+          <feature name="TH"/>
+        </orTerm>
+      </mandatoryConform>
+    </command>
+    <command source="client" code="0x09" name="QueryIdentity" optional="true" response="QueryIdentityResponse" cli="chip network_commissioning queryidentity">
+      <description>Retrieve details about and optionally proof of possession of a network client identity.</description>
+      <arg name="KeyIdentifier" type="octet_string" length="20"/>
+      <arg name="PossessionNonce" type="octet_string" length="32" optional="true"/>
+      <access op="invoke" privilege="administer"/>
+      <mandatoryConform>
+        <feature name="PDC"/>
+      </mandatoryConform>
+    </command>
+    <command source="server" code="0x0a" name="QueryIdentityResponse" optional="true">
+      <description>Command that contains details about a network client identity and optionally a proof of possession.</description>
+      <arg name="Identity" type="octet_string" length="140"/>
+      <arg name="PossessionSignature" type="octet_string" length="64" optional="true"/>
+      <mandatoryConform>
+        <feature name="PDC"/>
+      </mandatoryConform>
+    </command>
+  </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/occupancy-sensing-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/occupancy-sensing-cluster.xml
@@ -83,74 +83,288 @@ limitations under the License.
 
     <globalAttribute side="either" code="0xFFFD" value="5"/>
 
-    <attribute side="server" code="0x0000" define="OCCUPANCY" type="OccupancyBitmap" min="0x00" max="0x01" writable="false" reportable="true" optional="false">Occupancy</attribute>
-    <attribute side="server" code="0x0001" define="OCCUPANCY_SENSOR_TYPE" type="OccupancySensorTypeEnum" min="0x00" max="0xFE" writable="false" optional="false">OccupancySensorType</attribute>
-    <attribute side="server" code="0x0002" define="OCCUPANCY_SENSOR_TYPE_BITMAP" type="OccupancySensorTypeBitmap" min="0x00" max="0x07" writable="false" optional="false">OccupancySensorTypeBitmap</attribute>
-
-    <attribute side="server" code="0x0003" define="HOLD_TIME" type="int16u" writable="true" optional="true">
-        <description>HoldTime</description>
-        <access op="write" privilege="manage"/>
+    <attribute side="server" code="0x0000" define="OCCUPANCY" type="OccupancyBitmap" min="0x00" max="0x01" reportable="true">
+      <description>Occupancy</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="OCCUPANCY_SENSOR_TYPE" type="OccupancySensorTypeEnum" min="0x00" max="0xFE">
+      <description>OccupancySensorType</description>
+      <otherwiseConform>
+        <mandatoryConform/>
+        <deprecateConform/>
+      </otherwiseConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="OCCUPANCY_SENSOR_TYPE_BITMAP" type="OccupancySensorTypeBitmap" min="0x00" max="0x07">
+      <description>OccupancySensorTypeBitmap</description>
+      <otherwiseConform>
+        <mandatoryConform/>
+        <deprecateConform/>
+      </otherwiseConform>
     </attribute>
 
-    <attribute side="server" code="0x0004" define="HOLD_TIME_LIMITS" type="HoldTimeLimitsStruct" writable="false" optional="true">HoldTimeLimits</attribute>
+    <attribute side="server" code="0x0003" define="HOLD_TIME" type="int16u" writable="true" optional="true">
+      <description>HoldTime</description>
+      <access op="write" privilege="manage"/>
+      <optionalConform/>
+    </attribute>
 
+    <attribute side="server" code="0x0004" define="HOLD_TIME_LIMITS" type="HoldTimeLimitsStruct" optional="true">
+      <description>HoldTimeLimits</description>
+      <mandatoryConform>
+        <attribute name="HoldTime"/>
+      </mandatoryConform>
+    </attribute>
+    
     <attribute side="server" code="0x0010" define="PIR_OCCUPIED_TO_UNOCCUPIED_DELAY" type="int16u" writable="true" default="0x0000" optional="true">
       <description>PIROccupiedToUnoccupiedDelay</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <otherwiseConform>
+        <optionalConform>
+          <andTerm>
+            <attribute name="HoldTime"/>
+            <orTerm>
+              <feature name="PIR"/>
+              <andTerm>
+                <notTerm>
+                  <feature name="PIR"/>
+                </notTerm>
+                <notTerm>
+                  <feature name="US"/>
+                </notTerm>
+                <notTerm>
+                  <feature name="PHY"/>
+                </notTerm>
+              </andTerm>
+            </orTerm>
+          </andTerm>
+        </optionalConform>
+        <deprecateConform/>
+      </otherwiseConform>
     </attribute>
 
     <attribute side="server" code="0x0011" define="PIR_UNOCCUPIED_TO_OCCUPIED_DELAY" type="int16u" writable="true" default="0x0000" optional="true">
       <description>PIRUnoccupiedToOccupiedDelay</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <otherwiseConform>
+        <mandatoryConform>
+          <andTerm>
+            <andTerm>
+              <attribute name="HoldTime"/>
+              <orTerm>
+                <feature name="PIR"/>
+                <andTerm>
+                  <notTerm>
+                    <feature name="PIR"/>
+                  </notTerm>
+                  <notTerm>
+                    <feature name="US"/>
+                  </notTerm>
+                  <notTerm>
+                    <feature name="PHY"/>
+                  </notTerm>
+                </andTerm>
+              </orTerm>
+            </andTerm>
+            <attribute name="PIRUnoccupiedToOccupiedThreshold"/>
+          </andTerm>
+        </mandatoryConform>
+        <optionalConform>
+          <andTerm>
+            <attribute name="HoldTime"/>
+            <orTerm>
+              <feature name="PIR"/>
+              <andTerm>
+                <notTerm>
+                  <feature name="PIR"/>
+                </notTerm>
+                <notTerm>
+                  <feature name="US"/>
+                </notTerm>
+                <notTerm>
+                  <feature name="PHY"/>
+                </notTerm>
+              </andTerm>
+            </orTerm>
+          </andTerm>
+        </optionalConform>
+        <deprecateConform/>
+      </otherwiseConform>
     </attribute>
 
     <attribute side="server" code="0x0012" define="PIR_UNOCCUPIED_TO_OCCUPIED_THRESHOLD" type="int8u" min="0x01" max="0xFE" writable="true" default="0x01" optional="true">
       <description>PIRUnoccupiedToOccupiedThreshold</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <otherwiseConform>
+        <mandatoryConform>
+          <andTerm>
+            <andTerm>
+              <attribute name="HoldTime"/>
+              <orTerm>
+                <feature name="PIR"/>
+                <andTerm>
+                  <notTerm>
+                    <feature name="PIR"/>
+                  </notTerm>
+                  <notTerm>
+                    <feature name="US"/>
+                  </notTerm>
+                  <notTerm>
+                    <feature name="PHY"/>
+                  </notTerm>
+                </andTerm>
+              </orTerm>
+            </andTerm>
+            <attribute name="PIRUnoccupiedToOccupiedDelay"/>
+          </andTerm>
+        </mandatoryConform>
+        <optionalConform>
+          <andTerm>
+            <attribute name="HoldTime"/>
+            <orTerm>
+              <feature name="PIR"/>
+              <andTerm>
+                <notTerm>
+                  <feature name="PIR"/>
+                </notTerm>
+                <notTerm>
+                  <feature name="US"/>
+                </notTerm>
+                <notTerm>
+                  <feature name="PHY"/>
+                </notTerm>
+              </andTerm>
+            </orTerm>
+          </andTerm>
+        </optionalConform>
+        <deprecateConform/>
+      </otherwiseConform>
     </attribute>
 
     <attribute side="server" code="0x0020" define="ULTRASONIC_OCCUPIED_TO_UNOCCUPIED_DELAY" type="int16u" writable="true" default="0x0000" optional="true">
       <description>UltrasonicOccupiedToUnoccupiedDelay</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <otherwiseConform>
+        <optionalConform>
+          <andTerm>
+            <attribute name="HoldTime"/>
+            <feature name="US"/>
+          </andTerm>
+        </optionalConform>
+        <deprecateConform/>
+      </otherwiseConform>
     </attribute>
 
     <attribute side="server" code="0x0021" define="ULTRASONIC_UNOCCUPIED_TO_OCCUPIED_DELAY" type="int16u" writable="true" default="0x0000" optional="true">
       <description>UltrasonicUnoccupiedToOccupiedDelay</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <otherwiseConform>
+        <mandatoryConform>
+          <andTerm>
+            <attribute name="HoldTime"/>
+            <feature name="US"/>
+            <attribute name="UltrasonicUnoccupiedToOccupiedThreshold"/>
+          </andTerm>
+        </mandatoryConform>
+        <optionalConform>
+          <andTerm>
+            <attribute name="HoldTime"/>
+            <feature name="US"/>
+          </andTerm>
+        </optionalConform>
+        <deprecateConform/>
+      </otherwiseConform>
     </attribute>
 
     <attribute side="server" code="0x0022" define="ULTRASONIC_UNOCCUPIED_TO_OCCUPIED_THRESHOLD" type="int8u" min="0x01" max="0xFE" writable="true" default="0x01" optional="true">
       <description>UltrasonicUnoccupiedToOccupiedThreshold</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <otherwiseConform>
+        <mandatoryConform>
+          <andTerm>
+            <attribute name="HoldTime"/>
+            <feature name="US"/>
+            <attribute name="UltrasonicUnoccupiedToOccupiedDelay"/>
+          </andTerm>
+        </mandatoryConform>
+        <optionalConform>
+          <andTerm>
+            <attribute name="HoldTime"/>
+            <feature name="US"/>
+          </andTerm>
+        </optionalConform>
+        <deprecateConform/>
+      </otherwiseConform>
     </attribute>
 
     <attribute side="server" code="0x0030" define="PHYSICAL_CONTACT_OCCUPIED_TO_UNOCCUPIED_DELAY" type="int16u" writable="true" default="0x0000" optional="true">
       <description>PhysicalContactOccupiedToUnoccupiedDelay</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <otherwiseConform>
+        <optionalConform>
+          <andTerm>
+            <attribute name="HoldTime"/>
+            <feature name="PHY"/>
+          </andTerm>
+        </optionalConform>
+        <deprecateConform/>
+      </otherwiseConform>
     </attribute>
 
     <attribute side="server" code="0x0031" define="PHYSICAL_CONTACT_UNOCCUPIED_TO_OCCUPIED_DELAY" type="int16u" writable="true" default="0x0000" optional="true">
       <description>PhysicalContactUnoccupiedToOccupiedDelay</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <otherwiseConform>
+        <mandatoryConform>
+          <andTerm>
+            <attribute name="HoldTime"/>
+            <feature name="PHY"/>
+            <attribute name="PhysicalContactUnoccupiedToOccupiedThreshold"/>
+          </andTerm>
+        </mandatoryConform>
+        <optionalConform>
+          <andTerm>
+            <attribute name="HoldTime"/>
+            <feature name="PHY"/>
+          </andTerm>
+        </optionalConform>
+        <deprecateConform/>
+      </otherwiseConform>
     </attribute>
 
     <attribute side="server" code="0x0032" define="PHYSICAL_CONTACT_UNOCCUPIED_TO_OCCUPIED_THRESHOLD" type="int8u" min="0x01" max="0xFE" writable="true" default="0x01" optional="true">
       <description>PhysicalContactUnoccupiedToOccupiedThreshold</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <otherwiseConform>
+        <mandatoryConform>
+          <andTerm>
+            <attribute name="HoldTime"/>
+            <feature name="PHY"/>
+            <attribute name="PhysicalContactUnoccupiedToOccupiedDelay"/>
+          </andTerm>
+        </mandatoryConform>
+        <optionalConform>
+          <andTerm>
+            <attribute name="HoldTime"/>
+            <feature name="PHY"/>
+          </andTerm>
+        </optionalConform>
+        <deprecateConform/>
+      </otherwiseConform>
     </attribute>
 
     <event side="server" code="0x00" priority="info" name="OccupancyChanged" optional="true">
       <description>If this event is supported, it SHALL be generated when the Occupancy attribute changes.</description>
       <field id="0" name="Occupancy" type="OccupancyBitmap"/>
+      <optionalConform/>
     </event>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/onoff-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/onoff-cluster.xml
@@ -81,37 +81,75 @@ limitations under the License.
         </optionalConform>
       </feature>
     </features>
-
-    <attribute side="server" code="0x0000" define="ON_OFF"               type="boolean" default="0" reportable="true"              >OnOff</attribute>
-    <attribute side="server" code="0x4000" define="GLOBAL_SCENE_CONTROL" type="boolean" default="1"                 optional="true">GlobalSceneControl</attribute>
-    <attribute side="server" code="0x4001" define="ON_TIME"              type="int16u"  default="0" writable="true" optional="true">OnTime</attribute>
-    <attribute side="server" code="0x4002" define="OFF_WAIT_TIME"        type="int16u"  default="0" writable="true" optional="true">OffWaitTime</attribute>
-    <attribute side="server" code="0x4003" define="START_UP_ON_OFF"      type="StartUpOnOffEnum" min="0" max="2" isNullable="true" writable="true" optional="true">
+    
+    <attribute side="server" code="0x0000" define="ON_OFF" type="boolean" default="0" reportable="true">
+      <description>OnOff</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x4000" define="GLOBAL_SCENE_CONTROL" type="boolean" default="1" optional="true">
+      <description>GlobalSceneControl</description>
+      <mandatoryConform>
+        <feature name="LT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x4001" define="ON_TIME" type="int16u" default="0" writable="true" optional="true">
+      <description>OnTime</description>
+      <mandatoryConform>
+        <feature name="LT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x4002" define="OFF_WAIT_TIME" type="int16u" default="0" writable="true" optional="true">
+      <description>OffWaitTime</description>
+      <mandatoryConform>
+        <feature name="LT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x4003" define="START_UP_ON_OFF" type="StartUpOnOffEnum" min="0" max="2" isNullable="true" writable="true" optional="true">
       <description>StartUpOnOff</description>
       <access op="read" privilege="view"/>
       <access op="write" privilege="manage"/>
+      <mandatoryConform>
+        <feature name="LT"/>
+      </mandatoryConform>
     </attribute>
 
     <command source="client" code="0x00" name="Off" optional="false">
       <description>On receipt of this command, a device SHALL enter its ‘Off’ state. This state is device dependent, but it is recommended that it is used for power off or similar functions. On receipt of the Off command, the OnTime attribute SHALL be set to 0.</description>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x01" name="On" optional="false">
       <description>On receipt of this command, a device SHALL enter its ‘On’ state. This state is device dependent, but it is recommended that it is used for power on or similar functions. On receipt of the On command, if the value of the OnTime attribute is equal to 0, the device SHALL set the OffWaitTime attribute to 0.</description>
+      <mandatoryConform>
+        <notTerm>
+          <feature name="OFFONLY"/>
+        </notTerm>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x02" name="Toggle" optional="false">
       <description>On receipt of this command, if a device is in its ‘Off’ state it SHALL enter its ‘On’ state. Otherwise, if it is in its ‘On’ state it SHALL enter its ‘Off’ state. On receipt of the Toggle command, if the value of the OnOff attribute is equal to FALSE and if the value of the OnTime attribute is equal to 0, the device SHALL set the OffWaitTime attribute to 0. If the value of the OnOff attribute is equal to TRUE, the OnTime attribute SHALL be set to 0.</description>
+      <mandatoryConform>
+        <notTerm>
+          <feature name="OFFONLY"/>
+        </notTerm>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x40" name="OffWithEffect" optional="true">
       <description>The OffWithEffect command allows devices to be turned off using enhanced ways of fading.</description>
       <arg name="EffectIdentifier" type="EffectIdentifierEnum"/>
       <arg name="EffectVariant" type="enum8"/>
+      <mandatoryConform>
+        <feature name="LT"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x41" name="OnWithRecallGlobalScene" optional="true">
       <description>The OnWithRecallGlobalScene command allows the recall of the settings when the device was turned off.</description>
+      <mandatoryConform>
+        <feature name="LT"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x42" name="OnWithTimedOff" optional="true">
@@ -119,6 +157,9 @@ limitations under the License.
       <arg name="OnOffControl" type="OnOffControlBitmap"/>
       <arg name="OnTime" type="int16u"/>
       <arg name="OffWaitTime" type="int16u"/>
+      <mandatoryConform>
+        <feature name="LT"/>
+      </mandatoryConform>
     </command>
   </cluster>
 

--- a/src/app/zap-templates/zcl/data-model/chip/operational-credentials-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/operational-credentials-cluster.xml
@@ -62,34 +62,54 @@ limitations under the License.
     <attribute side="server" code="0x0000" define="NOCS" type="array" entryType="NOCStruct" writable="false" optional="false">
       <description>NOCs</description>
       <access op="read" privilege="administer"/>
+      <mandatoryConform/>
     </attribute>
-    <attribute side="server" code="0x0001" define="FABRICS" type="array" entryType="FabricDescriptorStruct" writable="false" optional="false">Fabrics</attribute>
-    <attribute side="server" code="0x0002" define="SUPPORTED_FABRICS" type="int8u" writable="false" min="5" max="254" optional="false">SupportedFabrics</attribute>
-    <attribute side="server" code="0x0003" define="COMMISSIONED_FABRICS" type="int8u" writable="false" optional="false">CommissionedFabrics</attribute>
-    <attribute side="server" code="0x0004" define="TRUSTED_ROOT_CERTIFICATES" type="array" entryType="octet_string" writable="false" optional="false">TrustedRootCertificates</attribute>
-    <attribute side="server" code="0x0005" define="CURRENT_FABRIC_INDEX" type="int8u" writable="false" optional="false">CurrentFabricIndex</attribute>
+    <attribute side="server" code="0x0001" define="FABRICS" type="array" entryType="FabricDescriptorStruct">
+      <description>Fabrics</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="SUPPORTED_FABRICS" type="int8u" min="5" max="254">
+      <description>SupportedFabrics</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="COMMISSIONED_FABRICS" type="int8u">
+      <description>CommissionedFabrics</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0004" define="TRUSTED_ROOT_CERTIFICATES" type="array" entryType="octet_string">
+      <description>TrustedRootCertificates</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0005" define="CURRENT_FABRIC_INDEX" type="int8u">
+      <description>CurrentFabricIndex</description>
+      <mandatoryConform/>
+    </attribute>
 
     <command source="client" code="0x00" name="AttestationRequest" response="AttestationResponse" optional="false">
       <description>Sender is requesting attestation information from the receiver.</description>
       <arg name="AttestationNonce" type="octet_string" length="32"/>
       <access op="invoke" privilege="administer"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x01" name="AttestationResponse" optional="false">
       <description>An attestation information confirmation from the server.</description>
       <arg name="AttestationElements" type="octet_string" length="900"/>
       <arg name="AttestationSignature" type="octet_string" length="64"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x02" name="CertificateChainRequest" response="CertificateChainResponse" optional="false">
       <description>Sender is requesting a device attestation certificate from the receiver.</description>
       <arg name="CertificateType" type="CertificateChainTypeEnum"/>
       <access op="invoke" privilege="administer"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x03" name="CertificateChainResponse" optional="false">
       <description>A device attestation certificate (DAC) or product attestation intermediate (PAI) certificate from the server.</description>
       <arg name="Certificate" type="octet_string" length="600"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x04" name="CSRRequest" response="CSRResponse" optional="false">
@@ -97,6 +117,7 @@ limitations under the License.
       <arg name="CSRNonce" type="octet_string" length="32"/>
       <arg name="IsForUpdateNOC" type="boolean" optional="true"/>
       <access op="invoke" privilege="administer"/>
+      <mandatoryConform/>
     </command>
 
     <!-- TODO: Fix to match chip-spec:#3346 -->
@@ -104,6 +125,7 @@ limitations under the License.
       <description>A certificate signing request (CSR) from the server.</description>
       <arg name="NOCSRElements" type="octet_string"/>
       <arg name="AttestationSignature" type="octet_string"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x06" name="AddNOC" response="NOCResponse" optional="false">
@@ -114,6 +136,7 @@ limitations under the License.
       <arg name="CaseAdminSubject" type="int64u"/>
       <arg name="AdminVendorId" type="vendor_id"/>
       <access op="invoke" privilege="administer"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x07" name="UpdateNOC" response="NOCResponse" isFabricScoped="true" optional="false">
@@ -121,31 +144,36 @@ limitations under the License.
       <arg name="NOCValue" type="octet_string"/>
       <arg name="ICACValue" type="octet_string" optional="true"/>
       <access op="invoke" privilege="administer"/>
+      <mandatoryConform/>
     </command>
 
-    <command source="server" code="0x08" name="NOCResponse" optional="false">
+   <command source="server" code="0x08" name="NOCResponse" optional="false">
       <description>Response to AddNOC or UpdateNOC commands.</description>
       <arg name="StatusCode" type="NodeOperationalCertStatusEnum"/>
       <arg name="FabricIndex" type="fabric_idx" optional="true"/>
       <arg name="DebugText" type="char_string" optional="true" length="128"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x09" name="UpdateFabricLabel" response="NOCResponse" isFabricScoped="true" optional="false">
       <description>This command SHALL be used by an Administrative Node to set the user-visible Label field for a given Fabric, as reflected by entries in the Fabrics attribute.</description>
       <arg name="Label" type="char_string" length="32"/>
       <access op="invoke" privilege="administer"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x0a" name="RemoveFabric" response="NOCResponse" optional="false">
       <description>This command is used by Administrative Nodes to remove a given fabric index and delete all associated fabric-scoped data.</description>
       <arg name="FabricIndex" type="fabric_idx"/>
       <access op="invoke" privilege="administer"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x0b" name="AddTrustedRootCertificate" optional="false">
       <description>This command SHALL add a Trusted Root CA Certificate, provided as its CHIP Certificate representation.</description>
       <arg name="RootCACertificate" type="octet_string"/>
       <access op="invoke" privilege="administer"/>
+      <mandatoryConform/>
     </command>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/operational-state-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/operational-state-cluster.xml
@@ -58,47 +58,94 @@ limitations under the License.
     <client init="false" tick="false">true</client>
     <server init="false" tick="false">true</server>
     <description>This cluster supports remotely monitoring and, where supported, changing the operational state of any device where a state machine is a part of the operation.</description>
-
-    <globalAttribute side="either" code="0xFFFD" value="1" />
-
-    <attribute side="server" code="0x0000" define="PHASE_LIST"              type="array" entryType="char_string"                                     writable="false" isNullable="true"  optional="false">PhaseList</attribute>
-    <attribute side="server" code="0x0001" define="CURRENT_PHASE"           type="int8u"                                    min="0x00" max="0x1F"    writable="false" isNullable="true"  optional="false">CurrentPhase</attribute>
-    <attribute side="server" code="0x0002" define="COUNTDOWN_TIME"          type="elapsed_s"                                min="0x00" max="259200"  writable="false" isNullable="true"  optional="true">CountdownTime</attribute>
-    <attribute side="server" code="0x0003" define="OPERATIONAL_STATE_LIST"  type="array" entryType="OperationalStateStruct"                          writable="false"                    optional="false">OperationalStateList</attribute>
-    <attribute side="server" code="0x0004" define="OPERATIONAL_STATE"       type="OperationalStateEnum"                                              writable="false"                    optional="false">OperationalState</attribute>
-    <attribute side="server" code="0x0005" define="OPERATIONAL_ERROR"       type="ErrorStateStruct"                                                  writable="false"                    optional="false">OperationalError</attribute>
-
+    
+    <globalAttribute side="either" code="0xFFFD" value="1"/>
+    
+    <attribute side="server" code="0x0000" define="PHASE_LIST" type="array" entryType="char_string" isNullable="true">
+      <description>PhaseList</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="CURRENT_PHASE" type="int8u" min="0x00" max="0x1F" isNullable="true">
+      <description>CurrentPhase</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="COUNTDOWN_TIME" type="elapsed_s" min="0x00" max="259200" isNullable="true" optional="true">
+      <description>CountdownTime</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="OPERATIONAL_STATE_LIST" type="array" entryType="OperationalStateStruct">
+      <description>OperationalStateList</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0004" define="OPERATIONAL_STATE" type="OperationalStateEnum">
+      <description>OperationalState</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0005" define="OPERATIONAL_ERROR" type="ErrorStateStruct">
+      <description>OperationalError</description>
+      <mandatoryConform/>
+    </attribute>
+    
     <command source="client" code="0x00" name="Pause" response="OperationalCommandResponse" optional="true">
       <description>Upon receipt, the device SHALL pause its operation if it is possible based on the current function of the server.</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <command name="Resume"/>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
     </command>
 
     <command source="client" code="0x01" name="Stop" response="OperationalCommandResponse" optional="true">
       <description>Upon receipt, the device SHALL stop its operation if it is at a position where it is safe to do so and/or permitted.</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <command name="Start"/>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
     </command>
 
     <command source="client" code="0x02" name="Start" response="OperationalCommandResponse" optional="true">
       <description>Upon receipt, the device SHALL start its operation if it is safe to do so and the device is in an operational state from which it can be started.</description>
+      <optionalConform/>
     </command>
 
     <command source="client" code="0x03" name="Resume" response="OperationalCommandResponse" optional="true">
       <description>Upon receipt, the device SHALL resume its operation from the point it was at when it received the Pause command, or from the point when it was paused by means outside of this cluster (for example by manual button press).</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <command name="Pause"/>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
     </command>
 
     <command source="server" code="0x04" name="OperationalCommandResponse" optional="true">
       <description>This command SHALL be generated in response to any of the Start, Stop, Pause, or Resume commands.</description>
       <arg name="CommandResponseState" type="ErrorStateStruct"/>
+      <mandatoryConform>
+        <orTerm>
+          <command name="Pause"/>
+          <command name="Stop"/>
+          <command name="Start"/>
+          <command name="Resume"/>
+        </orTerm>
+      </mandatoryConform>
     </command>
 
     <event side="server" code="0x00" priority="critical" name="OperationalError" optional="false">
       <description>OperationalError</description>
-      <field id="0" name="ErrorState" type="ErrorStateStruct" />
+      <field id="0" name="ErrorState" type="ErrorStateStruct"/>
+      <mandatoryConform/>
     </event>
 
      <event side="server" code="0x01" priority="info" name="OperationCompletion" optional="true">
       <description>OperationCompletion</description>
       <field id="0" name="CompletionErrorCode"  type="enum8" />
       <field id="1" name="TotalOperationalTime" type="elapsed_s" isNullable="true" optional="true"/>
-      <field id="2" name="PausedTime"           type="elapsed_s" isNullable="true" optional="true"/>
+      <field id="2" name="PausedTime" type="elapsed_s" isNullable="true" optional="true"/>
+      <optionalConform/>
     </event>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/operational-state-oven-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/operational-state-oven-cluster.xml
@@ -53,13 +53,31 @@ limitations under the License.
     <description>This cluster supports remotely monitoring and, where supported, changing the operational state of an Oven.</description>
 
     <globalAttribute side="either" code="0xFFFD" value="1"/>
-
-    <attribute side="server" code="0x0000" define="PHASE_LIST"              type="array" entryType="char_string"                                     writable="false" isNullable="true"  optional="false">PhaseList</attribute>
-    <attribute side="server" code="0x0001" define="CURRENT_PHASE"           type="int8u"                                    min="0x00" max="0x1F"    writable="false" isNullable="true"  optional="false">CurrentPhase</attribute>
-    <attribute side="server" code="0x0002" define="COUNTDOWN_TIME"          type="elapsed_s"                                min="0x00" max="259200"  writable="false" isNullable="true"  optional="true">CountdownTime</attribute>
-    <attribute side="server" code="0x0003" define="OPERATIONAL_STATE_LIST"  type="array" entryType="OperationalStateStruct"                          writable="false"                    optional="false">OperationalStateList</attribute>
-    <attribute side="server" code="0x0004" define="OPERATIONAL_STATE"       type="OperationalStateEnum"                                              writable="false"                    optional="false">OperationalState</attribute>
-    <attribute side="server" code="0x0005" define="OPERATIONAL_ERROR"       type="ErrorStateStruct"                                                  writable="false"                    optional="false">OperationalError</attribute>
+    
+    <attribute side="server" code="0x0000" define="PHASE_LIST" type="array" entryType="char_string" isNullable="true">
+      <description>PhaseList</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="CURRENT_PHASE" type="int8u" min="0x00" max="0x1F" isNullable="true">
+      <description>CurrentPhase</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="COUNTDOWN_TIME" type="elapsed_s" min="0x00" max="259200" isNullable="true" optional="true">
+      <description>CountdownTime</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="OPERATIONAL_STATE_LIST" type="array" entryType="OperationalStateStruct">
+      <description>OperationalStateList</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0004" define="OPERATIONAL_STATE" type="OperationalStateEnum">
+      <description>OperationalState</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0005" define="OPERATIONAL_ERROR" type="ErrorStateStruct">
+      <description>OperationalError</description>
+      <mandatoryConform/>
+    </attribute>
 
     <command source="client" code="0x00" name="Pause" response="OperationalCommandResponse" optional="true">
       <description>Upon receipt, the device SHALL pause its operation if it is possible based on the current function of the server.</description>
@@ -67,10 +85,17 @@ limitations under the License.
 
     <command source="client" code="0x01" name="Stop" response="OperationalCommandResponse" optional="true">
       <description>Upon receipt, the device SHALL stop its operation if it is at a position where it is safe to do so and/or permitted.</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <command name="Start"/>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
     </command>
 
     <command source="client" code="0x02" name="Start" response="OperationalCommandResponse" optional="true">
       <description>Upon receipt, the device SHALL start its operation if it is safe to do so and the device is in an operational state from which it can be started.</description>
+      <optionalConform/>
     </command>
 
     <command source="client" code="0x03" name="Resume" response="OperationalCommandResponse" optional="true">
@@ -80,18 +105,28 @@ limitations under the License.
     <command source="server" code="0x04" name="OperationalCommandResponse" optional="true">
       <description>This command SHALL be generated in response to any of the Start, Stop, Pause, or Resume commands.</description>
       <arg name="CommandResponseState" type="ErrorStateStruct"/>
+      <mandatoryConform>
+        <orTerm>
+          <command name="Pause"/>
+          <command name="Stop"/>
+          <command name="Start"/>
+          <command name="Resume"/>
+        </orTerm>
+      </mandatoryConform>
     </command>
 
     <event side="server" code="0x00" priority="critical" name="OperationalError" optional="false">
       <description>OperationalError</description>
-      <field id="0" name="ErrorState" type="ErrorStateStruct" />
+      <field id="0" name="ErrorState" type="ErrorStateStruct"/>
+      <mandatoryConform/>
     </event>
 
      <event side="server" code="0x01" priority="info" name="OperationCompletion" optional="true">
       <description>OperationCompletion</description>
       <field id="0" name="CompletionErrorCode"  type="enum8" />
       <field id="1" name="TotalOperationalTime" type="elapsed_s" isNullable="true" optional="true"/>
-      <field id="2" name="PausedTime"           type="elapsed_s" isNullable="true" optional="true"/>
+      <field id="2" name="PausedTime" type="elapsed_s" isNullable="true" optional="true"/>
+      <optionalConform/>
     </event>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/operational-state-rvc-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/operational-state-rvc-cluster.xml
@@ -64,24 +64,48 @@ limitations under the License.
     <client init="false" tick="false">true</client>
     <server init="false" tick="false">true</server>
     <description>This cluster supports remotely monitoring and, where supported, changing the operational state of a Robotic Vacuum.</description>
-
-    <globalAttribute side="either" code="0xFFFD" value="1" />
-
-    <attribute side="server" code="0x0000" define="PHASE_LIST"              type="array" entryType="char_string"                                     writable="false" isNullable="true"  optional="false">PhaseList</attribute>
-    <attribute side="server" code="0x0001" define="CURRENT_PHASE"           type="int8u"                                    min="0x00" max="0x1F"    writable="false" isNullable="true"  optional="false">CurrentPhase</attribute>
-    <attribute side="server" code="0x0002" define="COUNTDOWN_TIME"          type="elapsed_s"                                min="0"    max="259200"  writable="false" isNullable="true"  optional="true">CountdownTime</attribute>
-    <attribute side="server" code="0x0003" define="OPERATIONAL_STATE_LIST"  type="array" entryType="OperationalStateStruct"                          writable="false"                    optional="false">OperationalStateList</attribute>
-
-<!--
+    
+    <globalAttribute side="either" code="0xFFFD" value="1"/>
+    
+    <attribute side="server" code="0x0000" define="PHASE_LIST" type="array" entryType="char_string" isNullable="true">
+      <description>PhaseList</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="CURRENT_PHASE" type="int8u" min="0x00" max="0x1F" isNullable="true">
+      <description>CurrentPhase</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="COUNTDOWN_TIME" type="elapsed_s" min="0" max="259200" isNullable="true" optional="true">
+      <description>CountdownTime</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="OPERATIONAL_STATE_LIST" type="array" entryType="OperationalStateStruct">
+      <description>OperationalStateList</description>
+      <mandatoryConform/>
+    </attribute>
+    
+    <!--
 The type of this attribute in the spec is OperationalStateEnum, but the OperationalStateEnum in our XML
 excludes the values from the base OperationalState cluster.  Just use ENUM8 for the type, so it allows
 both values from this cluster and from the base cluster.
 -->
-    <attribute side="server" code="0x0004" define="OPERATIONAL_STATE"       type="enum8"                                                             writable="false"                    optional="false">OperationalState</attribute>
-    <attribute side="server" code="0x0005" define="OPERATIONAL_ERROR"       type="ErrorStateStruct"                                                  writable="false"                    optional="false">OperationalError</attribute>
+    <attribute side="server" code="0x0004" define="OPERATIONAL_STATE" type="enum8">
+      <description>OperationalState</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0005" define="OPERATIONAL_ERROR" type="ErrorStateStruct">
+      <description>OperationalError</description>
+      <mandatoryConform/>
+    </attribute>
 
     <command source="client" code="0x00" name="Pause" response="OperationalCommandResponse" optional="true">
       <description>Upon receipt, the device SHALL pause its operation if it is possible based on the current function of the server.</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <command name="Resume"/>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
     </command>
 
     <!-- Command Stop with code 0x01 is deprecated -->
@@ -90,27 +114,47 @@ both values from this cluster and from the base cluster.
 
     <command source="client" code="0x03" name="Resume" response="OperationalCommandResponse" optional="true">
       <description>Upon receipt, the device SHALL resume its operation from the point it was at when it received the Pause command, or from the point when it was paused by means outside of this cluster (for example by manual button press).</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <command name="Pause"/>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
     </command>
 
     <command source="server" code="0x04" name="OperationalCommandResponse" optional="true">
       <description>This command SHALL be generated in response to any of the Start, Stop, Pause, or Resume commands.</description>
       <arg name="CommandResponseState" type="ErrorStateStruct"/>
+      <mandatoryConform>
+        <orTerm>
+          <command name="Pause"/>
+          <command name="Stop"/>
+          <command name="Start"/>
+          <command name="Resume"/>
+        </orTerm>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x80" name="GoHome" response="OperationalCommandResponse" optional="true">
       <description>On receipt of this command, the device SHALL start seeking the charging dock, if possible in the current state of the device.</description>
+      <otherwiseConform>
+        <provisionalConform/>
+        <optionalConform/>
+      </otherwiseConform>
     </command>
 
     <event side="server" code="0x00" priority="critical" name="OperationalError" optional="false">
       <description>OperationalError</description>
-      <field id="0" name="ErrorState" type="ErrorStateStruct" />
+      <field id="0" name="ErrorState" type="ErrorStateStruct"/>
+      <mandatoryConform/>
     </event>
 
-     <event side="server" code="0x01" priority="info" name="OperationCompletion" optional="true">
+    <event side="server" code="0x01" priority="info" name="OperationCompletion" optional="true">
       <description>OperationCompletion</description>
       <field id="0" name="CompletionErrorCode"  type="enum8"                            optional="false"/>
-      <field id="1" name="TotalOperationalTime" type="elapsed_s"      isNullable="true" optional="true"/>
-      <field id="2" name="PausedTime"           type="elapsed_s"      isNullable="true" optional="true"/>
+      <field id="1" name="TotalOperationalTime" type="elapsed_s" isNullable="true" optional="true"/>
+      <field id="2" name="PausedTime" type="elapsed_s" isNullable="true" optional="true"/>
+      <optionalConform/>
     </event>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/oven-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/oven-mode-cluster.xml
@@ -62,11 +62,17 @@ limitations under the License.
     </features>
 
     <!-- Base data types -->
-    <attribute side="server" code="0x0000" define="SUPPORTED_MODES"  type="array" entryType="ModeOptionStruct" writable="false" optional="false" isNullable="false" length="255">SupportedModes</attribute>
-    <attribute side="server" code="0x0001" define="CURRENT_MODE"     type="int8u"                              writable="false" optional="false" isNullable="false" reportable="true">CurrentMode</attribute>
+    <attribute side="server" code="0x0000" define="SUPPORTED_MODES" type="array" entryType="ModeOptionStruct" length="255">
+      <description>SupportedModes</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="CURRENT_MODE" type="int8u" reportable="true">
+      <description>CurrentMode</description>
+      <mandatoryConform/>
+    </attribute>
     <attribute side="server" code="0x0002" define="START_UP_MODE"    type="int8u"                              writable="true"  optional="true"  isNullable="true">StartUpMode</attribute>
     <attribute side="server" code="0x0003" define="ON_MODE"          type="int8u"                              writable="true"  optional="true"  isNullable="true">OnMode</attribute>
-
+    
     <!-- Commands -->
     <command source="client" code="0x00" name="ChangeToMode" response="ChangeToModeResponse" optional="false">
       <description>
@@ -74,6 +80,7 @@ limitations under the License.
         On receipt of this command the device SHALL respond with a ChangeToModeResponse command.
       </description>
       <arg name="NewMode" type="int8u" optional="false"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x01" name="ChangeToModeResponse" disableDefaultResponse="true" optional="false">
@@ -82,6 +89,7 @@ limitations under the License.
       </description>
       <arg name="Status"     type="enum8"                   optional="false"/>
       <arg name="StatusText" type="char_string" lenght="64" optional="true"/>
+      <mandatoryConform/>
     </command>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/power-source-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/power-source-cluster.xml
@@ -43,58 +43,222 @@ limitations under the License.
         </optionalConform>
       </feature>
     </features>
+
+    <attribute side="server" code="0x0000" define="POWER_SOURCE_STATUS" type="PowerSourceStatusEnum">
+      <description>Status</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="POWER_SOURCE_ORDER" type="int8u">
+      <description>Order</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="POWER_SOURCE_DESCRIPTION" type="char_string" length="60">
+      <description>Description</description>
+      <mandatoryConform/>
+    </attribute>
     
-    <attribute side="server" code="0x0000" define="POWER_SOURCE_STATUS" type="PowerSourceStatusEnum" writable="false">Status</attribute>
-    <attribute side="server" code="0x0001" define="POWER_SOURCE_ORDER" type="int8u" min="0x00" max="0xFF" writable="false">Order</attribute>
-    <attribute side="server" code="0x0002" define="POWER_SOURCE_DESCRIPTION" type="char_string" length="60" writable="false">Description</attribute>
-
-    <attribute side="server" code="0x0003" define="POWER_SOURCE_WIRED_ASSESSED_INPUT_VOLTAGE" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" isNullable="true">WiredAssessedInputVoltage</attribute>
-    <attribute side="server" code="0x0004" define="POWER_SOURCE_WIRED_ASSESSED_INPUT_FREQUENCY" type="int16u" min="0x0000" max="0xFFFF" writable="false" optional="true" isNullable="true">WiredAssessedInputFrequency</attribute>
-    <attribute side="server" code="0x0005" define="POWER_SOURCE_WIRED_CURRENT_TYPE" type="WiredCurrentTypeEnum" writable="false" optional="true">WiredCurrentType</attribute>
-    <attribute side="server" code="0x0006" define="POWER_SOURCE_WIRED_ASSESSED_CURRENT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" isNullable="true">WiredAssessedCurrent</attribute>
-    <attribute side="server" code="0x0007" define="POWER_SOURCE_WIRED_NOMINAL_VOLTAGE" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">WiredNominalVoltage</attribute>
-    <attribute side="server" code="0x0008" define="POWER_SOURCE_WIRED_MAXIMUM_CURRENT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">WiredMaximumCurrent</attribute>
-    <attribute side="server" code="0x0009" define="POWER_SOURCE_WIRED_PRESENT" type="boolean" writable="false" optional="true">WiredPresent</attribute>
-    <attribute side="server" code="0x000A" define="POWER_SOURCE_ACTIVE_WIRED_FAULTS" type="array" entryType="WiredFaultEnum" length="8" writable="false" optional="true">ActiveWiredFaults</attribute>
-
-    <attribute side="server" code="0x000B" define="POWER_SOURCE_BAT_VOLTAGE" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" isNullable="true">BatVoltage</attribute>
-    <attribute side="server" code="0x000C" define="POWER_SOURCE_BAT_PERCENT_REMAINING" type="int8u" min="0x00" max="0xC8" writable="false" optional="true" isNullable="true">BatPercentRemaining</attribute>
-    <attribute side="server" code="0x000D" define="POWER_SOURCE_BAT_TIME_REMAINING" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" isNullable="true">BatTimeRemaining</attribute>
-    <attribute side="server" code="0x000E" define="POWER_SOURCE_BAT_CHARGE_LEVEL" type="BatChargeLevelEnum" writable="false" optional="true">BatChargeLevel</attribute>
-    <attribute side="server" code="0x000F" define="POWER_SOURCE_BAT_REPLACEMENT_NEEDED" type="boolean" writable="false" optional="true">BatReplacementNeeded</attribute>
-    <attribute side="server" code="0x0010" define="POWER_SOURCE_BAT_REPLACEABILITY" type="BatReplaceabilityEnum" writable="false" optional="true">BatReplaceability</attribute>
-    <attribute side="server" code="0x0011" define="POWER_SOURCE_BAT_PRESENT" type="boolean" writable="false" optional="true">BatPresent</attribute>
-    <attribute side="server" code="0x0012" define="POWER_SOURCE_ACTIVE_BAT_FAULTS" type="array" entryType="BatFaultEnum" length="8" writable="false" optional="true">ActiveBatFaults</attribute>
-    <attribute side="server" code="0x0013" define="POWER_SOURCE_BAT_REPLACEMENT_DESCRIPTION" type="char_string" length="60" writable="false" optional="true">BatReplacementDescription</attribute>
-    <attribute side="server" code="0x0014" define="POWER_SOURCE_BAT_COMMON_DESIGNATION" type="BatCommonDesignationEnum" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">BatCommonDesignation</attribute>
-    <attribute side="server" code="0x0015" define="POWER_SOURCE_BAT_ANSI_DESIGNATION" type="char_string" length="20" writable="false" optional="true">BatANSIDesignation</attribute>
-    <attribute side="server" code="0x0016" define="POWER_SOURCE_BAT_IEC_DESIGNATION" type="char_string" length="20" writable="false" optional="true">BatIECDesignation</attribute>
-    <attribute side="server" code="0x0017" define="POWER_SOURCE_BAT_APPROVED_CHEMISTRY" type="BatApprovedChemistryEnum" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">BatApprovedChemistry</attribute>
-    <attribute side="server" code="0x0018" define="POWER_SOURCE_BAT_CAPACITY" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true">BatCapacity</attribute>
-    <attribute side="server" code="0x0019" define="POWER_SOURCE_BAT_QUANTITY" type="int8u" min="0x00" max="0xFF" writable="false" optional="true">BatQuantity</attribute>
-    <attribute side="server" code="0x001A" define="POWER_SOURCE_BAT_CHARGE_STATE" type="BatChargeStateEnum" writable="false" optional="true">BatChargeState</attribute>
-    <attribute side="server" code="0x001B" define="POWER_SOURCE_BAT_TIME_TO_FULL_CHARGE" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" isNullable="true">BatTimeToFullCharge</attribute>
-    <attribute side="server" code="0x001C" define="POWER_SOURCE_BAT_FUNCTIONAL_WHILE_CHARGING" type="boolean" writable="false" optional="true">BatFunctionalWhileCharging</attribute>
-    <attribute side="server" code="0x001D" define="POWER_SOURCE_BAT_CHARGING_CURRENT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" optional="true" isNullable="true">BatChargingCurrent</attribute>
-    <attribute side="server" code="0x001E" define="POWER_SOURCE_ACTIVE_BAT_CHARGE_FAULTS" type="array" entryType="BatChargeFaultEnum" length="16" writable="false" optional="true">ActiveBatChargeFaults</attribute>
-    <attribute side="server" code="0x001F" define="POWER_SOURCE_ENDPOINT_LIST" type="array" entryType="endpoint_no" writable="false">EndpointList</attribute>
-
+    <attribute side="server" code="0x0003" define="POWER_SOURCE_WIRED_ASSESSED_INPUT_VOLTAGE" type="int32u" optional="true" isNullable="true">
+      <description>WiredAssessedInputVoltage</description>
+      <optionalConform>
+        <feature name="WIRED"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="POWER_SOURCE_WIRED_ASSESSED_INPUT_FREQUENCY" type="int16u" optional="true" isNullable="true">
+      <description>WiredAssessedInputFrequency</description>
+      <optionalConform>
+        <feature name="WIRED"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="POWER_SOURCE_WIRED_CURRENT_TYPE" type="WiredCurrentTypeEnum" optional="true">
+      <description>WiredCurrentType</description>
+      <mandatoryConform>
+        <feature name="WIRED"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="POWER_SOURCE_WIRED_ASSESSED_CURRENT" type="int32u" optional="true" isNullable="true">
+      <description>WiredAssessedCurrent</description>
+      <optionalConform>
+        <feature name="WIRED"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="POWER_SOURCE_WIRED_NOMINAL_VOLTAGE" type="int32u" optional="true">
+      <description>WiredNominalVoltage</description>
+      <optionalConform>
+        <feature name="WIRED"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="POWER_SOURCE_WIRED_MAXIMUM_CURRENT" type="int32u" optional="true">
+      <description>WiredMaximumCurrent</description>
+      <optionalConform>
+        <feature name="WIRED"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="POWER_SOURCE_WIRED_PRESENT" type="boolean" optional="true">
+      <description>WiredPresent</description>
+      <optionalConform>
+        <feature name="WIRED"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x000A" define="POWER_SOURCE_ACTIVE_WIRED_FAULTS" type="array" entryType="WiredFaultEnum" length="8" optional="true">
+      <description>ActiveWiredFaults</description>
+      <optionalConform>
+        <feature name="WIRED"/>
+      </optionalConform>
+    </attribute>
+    
+    <attribute side="server" code="0x000B" define="POWER_SOURCE_BAT_VOLTAGE" type="int32u" optional="true" isNullable="true">
+      <description>BatVoltage</description>
+      <optionalConform>
+        <feature name="BAT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x000C" define="POWER_SOURCE_BAT_PERCENT_REMAINING" type="int8u" max="0xC8" optional="true" isNullable="true">
+      <description>BatPercentRemaining</description>
+      <optionalConform>
+        <feature name="BAT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x000D" define="POWER_SOURCE_BAT_TIME_REMAINING" type="int32u" optional="true" isNullable="true">
+      <description>BatTimeRemaining</description>
+      <optionalConform>
+        <feature name="BAT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x000E" define="POWER_SOURCE_BAT_CHARGE_LEVEL" type="BatChargeLevelEnum" optional="true">
+      <description>BatChargeLevel</description>
+      <mandatoryConform>
+        <feature name="BAT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x000F" define="POWER_SOURCE_BAT_REPLACEMENT_NEEDED" type="boolean" optional="true">
+      <description>BatReplacementNeeded</description>
+      <mandatoryConform>
+        <feature name="BAT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0010" define="POWER_SOURCE_BAT_REPLACEABILITY" type="BatReplaceabilityEnum" optional="true">
+      <description>BatReplaceability</description>
+      <mandatoryConform>
+        <feature name="BAT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0011" define="POWER_SOURCE_BAT_PRESENT" type="boolean" optional="true">
+      <description>BatPresent</description>
+      <optionalConform>
+        <feature name="BAT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0012" define="POWER_SOURCE_ACTIVE_BAT_FAULTS" type="array" entryType="BatFaultEnum" length="8" optional="true">
+      <description>ActiveBatFaults</description>
+      <optionalConform>
+        <feature name="BAT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0013" define="POWER_SOURCE_BAT_REPLACEMENT_DESCRIPTION" type="char_string" length="60" optional="true">
+      <description>BatReplacementDescription</description>
+      <mandatoryConform>
+        <feature name="REPLC"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0014" define="POWER_SOURCE_BAT_COMMON_DESIGNATION" type="BatCommonDesignationEnum" min="0x00000000" max="0xFFFFFFFF" optional="true">
+      <description>BatCommonDesignation</description>
+      <optionalConform>
+        <feature name="REPLC"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0015" define="POWER_SOURCE_BAT_ANSI_DESIGNATION" type="char_string" length="20" optional="true">
+      <description>BatANSIDesignation</description>
+      <optionalConform>
+        <feature name="REPLC"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0016" define="POWER_SOURCE_BAT_IEC_DESIGNATION" type="char_string" length="20" optional="true">
+      <description>BatIECDesignation</description>
+      <optionalConform>
+        <feature name="REPLC"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0017" define="POWER_SOURCE_BAT_APPROVED_CHEMISTRY" type="BatApprovedChemistryEnum" min="0x00000000" max="0xFFFFFFFF" optional="true">
+      <description>BatApprovedChemistry</description>
+      <optionalConform>
+        <feature name="REPLC"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0018" define="POWER_SOURCE_BAT_CAPACITY" type="int32u" optional="true">
+      <description>BatCapacity</description>
+      <optionalConform>
+        <orTerm>
+          <feature name="REPLC"/>
+          <feature name="RECHG"/>
+        </orTerm>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0019" define="POWER_SOURCE_BAT_QUANTITY" type="int8u" optional="true">
+      <description>BatQuantity</description>
+      <mandatoryConform>
+        <feature name="REPLC"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x001A" define="POWER_SOURCE_BAT_CHARGE_STATE" type="BatChargeStateEnum" optional="true">
+      <description>BatChargeState</description>
+      <mandatoryConform>
+        <feature name="RECHG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x001B" define="POWER_SOURCE_BAT_TIME_TO_FULL_CHARGE" type="int32u" optional="true" isNullable="true">
+      <description>BatTimeToFullCharge</description>
+      <optionalConform>
+        <feature name="RECHG"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x001C" define="POWER_SOURCE_BAT_FUNCTIONAL_WHILE_CHARGING" type="boolean" optional="true">
+      <description>BatFunctionalWhileCharging</description>
+      <mandatoryConform>
+        <feature name="RECHG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x001D" define="POWER_SOURCE_BAT_CHARGING_CURRENT" type="int32u" optional="true" isNullable="true">
+      <description>BatChargingCurrent</description>
+      <optionalConform>
+        <feature name="RECHG"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x001E" define="POWER_SOURCE_ACTIVE_BAT_CHARGE_FAULTS" type="array" entryType="BatChargeFaultEnum" length="16" optional="true">
+      <description>ActiveBatChargeFaults</description>
+      <optionalConform>
+        <feature name="RECHG"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x001F" define="POWER_SOURCE_ENDPOINT_LIST" type="array" entryType="endpoint_no">
+      <description>EndpointList</description>
+      <mandatoryConform/>
+    </attribute>
+    
     <event code="0x0000" name="WiredFaultChange" priority="info" side="server" optional="true">
       <description>The WiredFaultChange Event SHALL indicate a change in the set of wired faults currently detected by the Node on this wired power source.</description>
       <field id="0" name="Current" type="WiredFaultEnum" array="true" length="8"/>
       <field id="1" name="Previous" type="WiredFaultEnum" array="true" length="8"/>
+      <optionalConform>
+        <feature name="WIRED"/>
+      </optionalConform>
     </event>
 
     <event code="0x0001" name="BatFaultChange" priority="info" side="server" optional="true">
       <description>The BatFaultChange Event SHALL indicate a change in the set of battery faults currently detected by the Node on this battery power source.</description>
       <field id="0" name="Current" type="BatFaultEnum" array="true" length="8"/>
       <field id="1" name="Previous" type="BatFaultEnum" array="true" length="8"/>
+      <optionalConform>
+        <feature name="BAT"/>
+      </optionalConform>
     </event>
 
     <event code="0x0002" name="BatChargeFaultChange" priority="info" side="server" optional="true">
       <description>The BatChargeFaultChange Event SHALL indicate a change in the set of charge faults currently detected by the Node on this battery power source.</description>
       <field id="0" name="Current" type="BatChargeFaultEnum" array="true" length="16"/>
       <field id="1" name="Previous" type="BatChargeFaultEnum" array="true" length="16"/>
+      <optionalConform>
+        <feature name="RECHG"/>
+      </optionalConform>
     </event>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/power-source-configuration-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/power-source-configuration-cluster.xml
@@ -26,6 +26,9 @@ limitations under the License.
     <client init="false" tick="false">true</client>
     <server init="false" tick="false">true</server>
     <globalAttribute side="either" code="0xFFFD" value="1"/>
-    <attribute side="server" code="0x0000" define="SOURCES" type="array" entryType="endpoint_no" length="6" writable="false" optional="false">Sources</attribute>
+    <attribute side="server" code="0x0000" define="SOURCES" type="array" entryType="endpoint_no" length="6">
+      <description>Sources</description>
+      <mandatoryConform/>
+    </attribute>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/power-topology-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/power-topology-cluster.xml
@@ -44,7 +44,17 @@ limitations under the License.
       </feature>
     </features>
     
-    <attribute code="0x0000" side="server" define="AVAILABLE_ENDPOINTS" type="array" entryType="endpoint_no" length="20" optional="true">AvailableEndpoints</attribute>
-    <attribute code="0x0001" side="server" define="ACTIVE_ENDPOINTS" type="array" entryType="endpoint_no" length="20" optional="true">ActiveEndpoints</attribute>
+    <attribute code="0x0000" side="server" define="AVAILABLE_ENDPOINTS" type="array" entryType="endpoint_no" length="20" optional="true">
+      <description>AvailableEndpoints</description>
+      <mandatoryConform>
+        <feature name="SET"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute code="0x0001" side="server" define="ACTIVE_ENDPOINTS" type="array" entryType="endpoint_no" length="20" optional="true">
+      <description>ActiveEndpoints</description>
+      <mandatoryConform>
+        <feature name="DYPF"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/pressure-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/pressure-measurement-cluster.xml
@@ -31,16 +31,53 @@ limitations under the License.
         <optionalConform/>
       </feature>
     </features>
-
-    <attribute side="server" code="0x0000" define="PRESSURE_MEASURED_VALUE" type="int16s" writable="false" reportable="true" optional="false" isNullable="true">MeasuredValue</attribute>
-    <attribute side="server" code="0x0001" define="PRESSURE_MIN_MEASURED_VALUE" type="int16s" writable="false" optional="false" isNullable="true">MinMeasuredValue</attribute>
-    <attribute side="server" code="0x0002" define="PRESSURE_MAX_MEASURED_VALUE" type="int16s" writable="false" optional="false" isNullable="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="PRESSURE_TOLERANCE" type="int16u" min="0x0000" max="0x0800" writable="false" optional="true" default="0">Tolerance</attribute>
-    <attribute side="server" code="0x0010" define="PRESSURE_SCALED_VALUE" type="int16s" writable="false" optional="true" default="0" isNullable="true">ScaledValue</attribute>
-    <attribute side="server" code="0x0011" define="PRESSURE_MIN_SCALED_VALUE" type="int16s" writable="false" optional="true" default="0" isNullable="true">MinScaledValue</attribute>
-    <attribute side="server" code="0x0012" define="PRESSURE_MAX_SCALED_VALUE" type="int16s" writable="false" optional="true" default="0" isNullable="true">MaxScaledValue</attribute>
-    <attribute side="server" code="0x0013" define="PRESSURE_SCALED_TOLERANCE" type="int16u" min="0x0000" max="0x0800" writable="false" reportable="true" optional="true" default="0">ScaledTolerance</attribute>
-    <attribute side="server" code="0x0014" define="PRESSURE_SCALE" type="int8s" writable="false" optional="true" default="0">Scale</attribute>
+    
+    <attribute side="server" code="0x0000" define="PRESSURE_MEASURED_VALUE" type="int16s" reportable="true" isNullable="true">
+      <description>MeasuredValue</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="PRESSURE_MIN_MEASURED_VALUE" type="int16s" isNullable="true">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="PRESSURE_MAX_MEASURED_VALUE" type="int16s" isNullable="true">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="PRESSURE_TOLERANCE" type="int16u" min="0x0000" max="0x0800" optional="true" default="0">
+      <description>Tolerance</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0010" define="PRESSURE_SCALED_VALUE" type="int16s" optional="true" default="0" isNullable="true">
+      <description>ScaledValue</description>
+      <mandatoryConform>
+        <feature name="EXT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0011" define="PRESSURE_MIN_SCALED_VALUE" type="int16s" optional="true" default="0" isNullable="true">
+      <description>MinScaledValue</description>
+      <mandatoryConform>
+        <feature name="EXT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0012" define="PRESSURE_MAX_SCALED_VALUE" type="int16s" optional="true" default="0" isNullable="true">
+      <description>MaxScaledValue</description>
+      <mandatoryConform>
+        <feature name="EXT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0013" define="PRESSURE_SCALED_TOLERANCE" type="int16u" min="0x0000" max="0x0800" optional="true" reportable="true" default="0">
+      <description>ScaledTolerance</description>
+      <optionalConform>
+        <feature name="EXT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0014" define="PRESSURE_SCALE" type="int8s" optional="true" default="0">
+      <description>Scale</description>
+      <mandatoryConform>
+        <feature name="EXT"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/pump-configuration-and-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/pump-configuration-and-control-cluster.xml
@@ -49,97 +49,245 @@ limitations under the License.
         <optionalConform/>
       </feature>
     </features>
-
-    <attribute side="server" code="0x0000" define="MAX_PRESSURE" type="int16s" isNullable="true" min="0x8001" max="0x7FFF" writable="false" optional="false">MaxPressure</attribute>
-    <attribute side="server" code="0x0001" define="MAX_SPEED" type="int16u" isNullable="true" min="0x0000" max="0xFFFE" writable="false" optional="false">MaxSpeed</attribute>
-    <attribute side="server" code="0x0002" define="MAX_FLOW" type="int16u" isNullable="true" min="0x0000" max="0xFFFE" writable="false" optional="false">MaxFlow</attribute>
-    <attribute side="server" code="0x0003" define="MIN_CONST_PRESSURE" type="int16s" isNullable="true" min="0x8001" max="0x7FFF" writable="false" optional="true">MinConstPressure</attribute>
-    <attribute side="server" code="0x0004" define="MAX_CONST_PRESSURE" type="int16s" isNullable="true" min="0x8001" max="0x7FFF" writable="false" optional="true">MaxConstPressure</attribute>
-    <attribute side="server" code="0x0005" define="MIN_COMP_PRESSURE" type="int16s" isNullable="true" min="0x8001" max="0x7FFF" writable="false" optional="true">MinCompPressure</attribute>
-    <attribute side="server" code="0x0006" define="MAX_COMP_PRESSURE" type="int16s" isNullable="true" min="0x8001" max="0x7FFF" writable="false" optional="true">MaxCompPressure</attribute>
-    <attribute side="server" code="0x0007" define="MIN_CONST_SPEED" type="int16u" isNullable="true" min="0x0000" max="0xFFFE" writable="false" optional="true">MinConstSpeed</attribute>
-    <attribute side="server" code="0x0008" define="MAX_CONST_SPEED" type="int16u" isNullable="true" min="0x0000" max="0xFFFE" writable="false" optional="true">MaxConstSpeed</attribute>
-    <attribute side="server" code="0x0009" define="MIN_CONST_FLOW" type="int16u" isNullable="true" min="0x0000" max="0xFFFE" writable="false" optional="true">MinConstFlow</attribute>
-    <attribute side="server" code="0x000A" define="MAX_CONST_FLOW" type="int16u" isNullable="true" min="0x0000" max="0xFFFE" writable="false" optional="true">MaxConstFlow</attribute>
-    <attribute side="server" code="0x000B" define="MIN_CONST_TEMP" type="int16s" isNullable="true" min="0x954D" max="32767" writable="false" optional="true">MinConstTemp</attribute>
-    <attribute side="server" code="0x000C" define="MAX_CONST_TEMP" type="int16s" isNullable="true" min="0x954D" max="0x7FFF" writable="false" optional="true">MaxConstTemp</attribute>
-    <attribute side="server" code="0x0010" define="PUMP_STATUS" type="PumpStatusBitmap" writable="false" default="0x0000" reportable="true" optional="true">PumpStatus</attribute>
-    <attribute side="server" code="0x0011" define="EFFECTIVE_OPERATION_MODE" type="OperationModeEnum" min="0x00" max="0x03" writable="false" optional="false">EffectiveOperationMode</attribute>
-    <attribute side="server" code="0x0012" define="EFFECTIVE_CONTROL_MODE" type="ControlModeEnum" min="0x00" max="0x07" writable="false" optional="false">EffectiveControlMode</attribute>
-    <attribute side="server" code="0x0013" define="CAPACITY" type="int16s" isNullable="true" min="0x0000" max="0x7FFF" writable="false" reportable="true" optional="false">Capacity</attribute>
-    <attribute side="server" code="0x0014" define="SPEED" type="int16u" isNullable="true" min="0x0000" max="0xFFFE" writable="false" optional="true">Speed</attribute>
+    
+    <attribute side="server" code="0x0000" define="MAX_PRESSURE" type="int16s" isNullable="true">
+      <description>MaxPressure</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MAX_SPEED" type="int16u" isNullable="true">
+      <description>MaxSpeed</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MAX_FLOW" type="int16u" isNullable="true">
+      <description>MaxFlow</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="MIN_CONST_PRESSURE" type="int16s" isNullable="true" optional="true">
+      <description>MinConstPressure</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <feature name="PRSCONST"/>
+        </mandatoryConform>
+        <optionalConform>
+          <feature name="AUTO"/>
+        </optionalConform>
+      </otherwiseConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="MAX_CONST_PRESSURE" type="int16s" isNullable="true" optional="true">
+      <description>MaxConstPressure</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <feature name="PRSCONST"/>
+        </mandatoryConform>
+        <optionalConform>
+          <feature name="AUTO"/>
+        </optionalConform>
+      </otherwiseConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="MIN_COMP_PRESSURE" type="int16s" isNullable="true" optional="true">
+      <description>MinCompPressure</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <feature name="PRSCOMP"/>
+        </mandatoryConform>
+        <optionalConform>
+          <feature name="AUTO"/>
+        </optionalConform>
+      </otherwiseConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="MAX_COMP_PRESSURE" type="int16s" isNullable="true" optional="true">
+      <description>MaxCompPressure</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <feature name="PRSCOMP"/>
+        </mandatoryConform>
+        <optionalConform>
+          <feature name="AUTO"/>
+        </optionalConform>
+      </otherwiseConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="MIN_CONST_SPEED" type="int16u" isNullable="true" optional="true">
+      <description>MinConstSpeed</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <feature name="SPD"/>
+        </mandatoryConform>
+        <optionalConform>
+          <feature name="AUTO"/>
+        </optionalConform>
+      </otherwiseConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="MAX_CONST_SPEED" type="int16u" isNullable="true" optional="true">
+      <description>MaxConstSpeed</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <feature name="SPD"/>
+        </mandatoryConform>
+        <optionalConform>
+          <feature name="AUTO"/>
+        </optionalConform>
+      </otherwiseConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="MIN_CONST_FLOW" type="int16u" isNullable="true" optional="true">
+      <description>MinConstFlow</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <feature name="FLW"/>
+        </mandatoryConform>
+        <optionalConform>
+          <feature name="AUTO"/>
+        </optionalConform>
+      </otherwiseConform>
+    </attribute>
+    <attribute side="server" code="0x000A" define="MAX_CONST_FLOW" type="int16u" isNullable="true" optional="true">
+      <description>MaxConstFlow</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <feature name="FLW"/>
+        </mandatoryConform>
+        <optionalConform>
+          <feature name="AUTO"/>
+        </optionalConform>
+      </otherwiseConform>
+    </attribute>
+    <attribute side="server" code="0x000B" define="MIN_CONST_TEMP" type="int16s" isNullable="true" min="0x954D" optional="true">
+      <description>MinConstTemp</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <feature name="TEMP"/>
+        </mandatoryConform>
+        <optionalConform>
+          <feature name="AUTO"/>
+        </optionalConform>
+      </otherwiseConform>
+    </attribute>
+    <attribute side="server" code="0x000C" define="MAX_CONST_TEMP" type="int16s" isNullable="true" min="0x954D" optional="true">
+      <description>MaxConstTemp</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <feature name="TEMP"/>
+        </mandatoryConform>
+        <optionalConform>
+          <feature name="AUTO"/>
+        </optionalConform>
+      </otherwiseConform>
+    </attribute>
+    <attribute side="server" code="0x0010" define="PUMP_STATUS" type="PumpStatusBitmap" default="0x0000" reportable="true" optional="true">
+      <description>PumpStatus</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0011" define="EFFECTIVE_OPERATION_MODE" type="OperationModeEnum" min="0x00" max="0x03">
+      <description>EffectiveOperationMode</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0012" define="EFFECTIVE_CONTROL_MODE" type="ControlModeEnum" min="0x00" max="0x07">
+      <description>EffectiveControlMode</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0013" define="CAPACITY" type="int16s" isNullable="true" reportable="true">
+      <description>Capacity</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0014" define="SPEED" type="int16u" isNullable="true" optional="true">
+      <description>Speed</description>
+      <optionalConform/>
+    </attribute>
     <attribute side="server" code="0x0015" define="LIFETIME_RUNNING_HOURS" type="int24u" isNullable="true" writable="true" default="0x000000" optional="true">
       <description>LifetimeRunningHours</description>
       <access op="read" privilege="view"/>
       <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
-    <attribute side="server" code="0x0016" define="PUMP_POWER" type="int24u" isNullable="true" writable="false" optional="true">Power</attribute>
+    <attribute side="server" code="0x0016" define="PUMP_POWER" type="int24u" isNullable="true" optional="true">
+      <description>Power</description>
+      <optionalConform/>
+    </attribute>
     <attribute side="server" code="0x0017" define="LIFETIME_ENERGY_CONSUMED" type="int32u" isNullable="true" writable="true" default="0x00000000" optional="true">
       <description>LifetimeEnergyConsumed</description>
       <access op="read" privilege="view"/>
       <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
     <attribute side="server" code="0x0020" define="OPERATION_MODE" type="OperationModeEnum" min="0x00" max="0x03" writable="true" default="0x00" optional="false">
       <description>OperationMode</description>
       <access op="read" privilege="view"/>
       <access op="write" privilege="manage"/>
+      <mandatoryConform/>
     </attribute>
     <attribute side="server" code="0x0021" define="CONTROL_MODE" type="ControlModeEnum" min="0x00" max="0x07" writable="true" default="0x00" optional="true">
       <description>ControlMode</description>
       <access op="read" privilege="view"/>
       <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
 
     <event side="server" code="0x00" priority="info" name="SupplyVoltageLow" optional="true">
       <description>SupplyVoltageLow</description>
+      <optionalConform/>
     </event>
     <event side="server" code="0x01" priority="info" name="SupplyVoltageHigh" optional="true">
       <description>SupplyVoltageHigh</description>
+      <optionalConform/>
     </event>
     <event side="server" code="0x02" priority="info" name="PowerMissingPhase" optional="true">
       <description>PowerMissingPhase</description>
+      <optionalConform/>
     </event>
     <event side="server" code="0x03" priority="info" name="SystemPressureLow" optional="true">
       <description>SystemPressureLow</description>
+      <optionalConform/>
     </event>
     <event side="server" code="0x04" priority="info" name="SystemPressureHigh" optional="true">
       <description>SystemPressureHigh</description>
+      <optionalConform/>
     </event>
     <event side="server" code="0x05" priority="critical" name="DryRunning" optional="true">
       <description>DryRunning</description>
+      <optionalConform/>
     </event>
     <event side="server" code="0x06" priority="info" name="MotorTemperatureHigh" optional="true">
       <description>MotorTemperatureHigh</description>
+      <optionalConform/>
     </event>
     <event side="server" code="0x07" priority="critical" name="PumpMotorFatalFailure" optional="true">
       <description>PumpMotorFatalFailure</description>
+      <optionalConform/>
     </event>
     <event side="server" code="0x08" priority="info" name="ElectronicTemperatureHigh" optional="true">
       <description>ElectronicTemperatureHigh</description>
+      <optionalConform/>
     </event>
     <event side="server" code="0x09" priority="critical" name="PumpBlocked" optional="true">
       <description>PumpBlocked</description>
+      <optionalConform/>
     </event>
     <event side="server" code="0x0A" priority="info" name="SensorFailure" optional="true">
       <description>SensorFailure</description>
+      <optionalConform/>
     </event>
     <event side="server" code="0x0B" priority="info" name="ElectronicNonFatalFailure" optional="true">
       <description>ElectronicNonFatalFailure</description>
+      <optionalConform/>
     </event>
     <event side="server" code="0x0C" priority="critical" name="ElectronicFatalFailure" optional="true">
       <description>ElectronicFatalFailure</description>
+      <optionalConform/>
     </event>
     <event side="server" code="0x0D" priority="info" name="GeneralFault" optional="true">
       <description>GeneralFault</description>
+      <optionalConform/>
     </event>
     <event side="server" code="0x0E" priority="info" name="Leakage" optional="true">
       <description>Leakage</description>
+      <optionalConform/>
     </event>
     <event side="server" code="0x0F" priority="info" name="AirDetection" optional="true">
       <description>AirDetection</description>
+      <optionalConform/>
     </event>
     <event side="server" code="0x10" priority="info" name="TurbineOperation" optional="true">
       <description>TurbineOperation</description>
+      <optionalConform/>
     </event>
   </cluster>
 

--- a/src/app/zap-templates/zcl/data-model/chip/refrigerator-alarm.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/refrigerator-alarm.xml
@@ -28,17 +28,27 @@ limitations under the License.
     <define>REFRIGERATOR_ALARM_CLUSTER</define>
     <client tick="false" init="false">true</client>
     <server tick="false" init="false">true</server>
-
-    <attribute side="server" code="0x0000" define="MASK" type="AlarmBitmap" default="0" writable="false" optional="false">Mask</attribute>
-    <attribute side="server" code="0x0002" define="STATE" type="AlarmBitmap" default="0" writable="false" optional="false">State</attribute>
-    <attribute side="server" code="0x0003" define="SUPPORTED" type="AlarmBitmap" default="0" writable="false" optional="false">Supported</attribute>
+    
+    <attribute side="server" code="0x0000" define="MASK" type="AlarmBitmap" default="0">
+      <description>Mask</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="STATE" type="AlarmBitmap" default="0">
+      <description>State</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="SUPPORTED" type="AlarmBitmap" default="0">
+      <description>Supported</description>
+      <mandatoryConform/>
+    </attribute>
 
     <event side="server" code="0x00" priority="info" name="Notify" optional="false">
-        <description>Notify</description>
-        <field id="0" name="Active" type="AlarmBitmap" />
-        <field id="1" name="Inactive" type="AlarmBitmap" />
-        <field id="2" name="State" type="AlarmBitmap" />
-        <field id="3" name="Mask" type="AlarmBitmap" />
+      <description>Notify</description>
+      <field id="0" name="Active" type="AlarmBitmap" />
+      <field id="1" name="Inactive" type="AlarmBitmap" />
+      <field id="2" name="State" type="AlarmBitmap" />
+      <field id="3" name="Mask" type="AlarmBitmap" />
+      <mandatoryConform/>
     </event>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/refrigerator-and-temperature-controlled-cabinet-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/refrigerator-and-temperature-controlled-cabinet-mode-cluster.xml
@@ -56,11 +56,17 @@ limitations under the License.
     </features>
 
     <!-- Base data types -->
-    <attribute side="server" code="0x0000" define="SUPPORTED_MODES"  type="array" entryType="ModeOptionStruct" writable="false" optional="false" isNullable="false" length="255">SupportedModes</attribute>
-    <attribute side="server" code="0x0001" define="CURRENT_MODE"     type="int8u"                              writable="false" optional="false" isNullable="false" reportable="true">CurrentMode</attribute>
+    <attribute side="server" code="0x0000" define="SUPPORTED_MODES" type="array" entryType="ModeOptionStruct" length="255">
+      <description>SupportedModes</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="CURRENT_MODE" type="int8u" reportable="true">
+      <description>CurrentMode</description>
+      <mandatoryConform/>
+    </attribute>
     <attribute side="server" code="0x0002" define="START_UP_MODE"    type="int8u"                              writable="true"  optional="true"  isNullable="true">StartUpMode</attribute>
     <attribute side="server" code="0x0003" define="ON_MODE"          type="int8u"                              writable="true"  optional="true"  isNullable="true">OnMode</attribute>
-
+    
     <!-- Commands -->
     <command source="client" code="0x00" name="ChangeToMode" response="ChangeToModeResponse" optional="false">
       <description>
@@ -68,6 +74,7 @@ limitations under the License.
         On receipt of this command the device SHALL respond with a ChangeToModeResponse command.
       </description>
       <arg name="NewMode" type="int8u" optional="false"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x01" name="ChangeToModeResponse" disableDefaultResponse="true" optional="false">
@@ -76,6 +83,7 @@ limitations under the License.
       </description>
       <arg name="Status"     type="enum8"                   optional="false"/>
       <arg name="StatusText" type="char_string" lenght="64" optional="true"/>
+      <mandatoryConform/>
     </command>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/relative-humidity-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/relative-humidity-measurement-cluster.xml
@@ -25,9 +25,21 @@ limitations under the License.
     <client tick="false" init="false">true</client>
     <server tick="false" tickFrequency="half" init="false">true</server>
     <globalAttribute side="either" code="0xFFFD" value="3"/>
-    <attribute side="server" code="0x0000" define="RELATIVE_HUMIDITY_MEASURED_VALUE" type="int16u" writable="false" reportable="true" optional="false" isNullable="true">MeasuredValue</attribute>
-    <attribute side="server" code="0x0001" define="RELATIVE_HUMIDITY_MIN_MEASURED_VALUE" type="int16u" min="0x0000" max="0x270F" writable="false" optional="false" isNullable="true">MinMeasuredValue</attribute>
-    <attribute side="server" code="0x0002" define="RELATIVE_HUMIDITY_MAX_MEASURED_VALUE" type="int16u" min="0x0001" max="0x2710" writable="false" optional="false" isNullable="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="RELATIVE_HUMIDITY_TOLERANCE" type="int16u" min="0x0000" max="0x0800" writable="false" optional="true">Tolerance</attribute>
+    <attribute side="server" code="0x0000" define="RELATIVE_HUMIDITY_MEASURED_VALUE" type="int16u" reportable="true" isNullable="true">
+      <description>MeasuredValue</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="RELATIVE_HUMIDITY_MIN_MEASURED_VALUE" type="int16u" min="0x0000" max="0x270F" isNullable="true">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="RELATIVE_HUMIDITY_MAX_MEASURED_VALUE" type="int16u" min="0x0001" max="0x2710" isNullable="true">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="RELATIVE_HUMIDITY_TOLERANCE" type="int16u" min="0x0000" max="0x0800" optional="true">
+      <description>Tolerance</description>
+      <optionalConform/>
+    </attribute>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/resource-monitoring-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/resource-monitoring-cluster.xml
@@ -38,16 +38,41 @@ limitations under the License.
     </features>
 
     <!-- Attributes -->
-    <attribute side="server" code="0x0000" define="CONDITION" type="percent" min="0" max="100" writable="false" isNullable="false" optional="true">Condition</attribute>
-    <attribute side="server" code="0x0001" define="DEGRADATION_DIRECTION" type="DegradationDirectionEnum" min="0" max="1" writable="false" isNullable="false" optional="true">DegradationDirection</attribute>
-    <attribute side="server" code="0x0002" define="CHANGE_INDICATION" type="ChangeIndicationEnum" min="0" max="2" writable="false" isNullable="false" default="0" optional="false">ChangeIndication</attribute>
-    <attribute side="server" code="0x0003" define="IN_PLACE_INDICATOR" type="boolean" writable="false" isNullable="false" optional="true">InPlaceIndicator</attribute>
-    <attribute side="server" code="0x0004" define="LAST_CHANGED_TIME" type="epoch_s" writable="true" isNullable="true" optional="true">LastChangedTime</attribute>
-    <attribute side="server" code="0x0005" define="REPLACEMENT_PRODUCT_LIST" type="array" entryType="ReplacementProductStruct" length="5" writable="false" isNullable="false" optional="true">ReplacementProductList</attribute>
-
+    <attribute side="server" code="0x0000" define="CONDITION" type="percent" optional="true">
+      <description>Condition</description>
+      <mandatoryConform>
+        <feature name="CON"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="DEGRADATION_DIRECTION" type="DegradationDirectionEnum" min="0" max="1" optional="true">
+      <description>DegradationDirection</description>
+      <mandatoryConform>
+        <feature name="CON"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="CHANGE_INDICATION" type="ChangeIndicationEnum" min="0" max="2" default="0">
+      <description>ChangeIndication</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="IN_PLACE_INDICATOR" type="boolean" optional="true">
+      <description>InPlaceIndicator</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0004" define="LAST_CHANGED_TIME" type="epoch_s" writable="true" isNullable="true" optional="true">
+      <description>LastChangedTime</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0005" define="REPLACEMENT_PRODUCT_LIST" type="array" entryType="ReplacementProductStruct" length="5" optional="true">
+      <description>ReplacementProductList</description>
+      <mandatoryConform>
+        <feature name="REP"/>
+      </mandatoryConform>
+    </attribute>
+    
     <!-- Commands -->
     <command source="client" code="0x00" name="ResetCondition" optional="true">
       <description>Reset the condition of the replaceable to the non degraded state</description>
+      <optionalConform/>
     </command>
   </cluster>
 
@@ -73,16 +98,41 @@ limitations under the License.
     </features>
 
     <!-- Attributes -->
-    <attribute side="server" code="0x0000" define="CONDITION" type="percent" min="0" max="100" writable="false" isNullable="false" optional="true">Condition</attribute>
-    <attribute side="server" code="0x0001" define="DEGRADATION_DIRECTION" type="DegradationDirectionEnum" min="0" max="1" writable="false" isNullable="false" optional="true">DegradationDirection</attribute>
-    <attribute side="server" code="0x0002" define="CHANGE_INDICATION" type="ChangeIndicationEnum" min="0" max="2" writable="false" isNullable="false" default="0" optional="false">ChangeIndication</attribute>
-    <attribute side="server" code="0x0003" define="IN_PLACE_INDICATOR" type="boolean" writable="false" isNullable="false" optional="true">InPlaceIndicator</attribute>
-    <attribute side="server" code="0x0004" define="LAST_CHANGED_TIME" type="epoch_s" writable="true" isNullable="true" optional="true">LastChangedTime</attribute>
-    <attribute side="server" code="0x0005" define="REPLACEMENT_PRODUCT_LIST" type="array" entryType="ReplacementProductStruct" length="5" writable="false" isNullable="false" optional="true">ReplacementProductList</attribute>
-
+    <attribute side="server" code="0x0000" define="CONDITION" type="percent" optional="true">
+      <description>Condition</description>
+      <mandatoryConform>
+        <feature name="CON"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="DEGRADATION_DIRECTION" type="DegradationDirectionEnum" min="0" max="1" optional="true">
+      <description>DegradationDirection</description>
+      <mandatoryConform>
+        <feature name="CON"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="CHANGE_INDICATION" type="ChangeIndicationEnum" min="0" max="2" default="0">
+      <description>ChangeIndication</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="IN_PLACE_INDICATOR" type="boolean" optional="true">
+      <description>InPlaceIndicator</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0004" define="LAST_CHANGED_TIME" type="epoch_s" writable="true" isNullable="true" optional="true">
+      <description>LastChangedTime</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0005" define="REPLACEMENT_PRODUCT_LIST" type="array" entryType="ReplacementProductStruct" length="5" optional="true">
+      <description>ReplacementProductList</description>
+      <mandatoryConform>
+        <feature name="REP"/>
+      </mandatoryConform>
+    </attribute>
+    
     <!-- Commands -->
     <command source="client" code="0x00" name="ResetCondition" optional="true">
       <description>Reset the condition of the replaceable to the non degraded state</description>
+      <optionalConform/>
     </command>
   </cluster>
 

--- a/src/app/zap-templates/zcl/data-model/chip/rvc-clean-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/rvc-clean-mode-cluster.xml
@@ -67,8 +67,14 @@ limitations under the License.
     </features>
 
     <!-- Base data types -->
-    <attribute side="server" code="0x0000" define="SUPPORTED_MODES"  type="array" entryType="ModeOptionStruct" writable="false" optional="false" isNullable="false" length="255">SupportedModes</attribute>
-    <attribute side="server" code="0x0001" define="CURRENT_MODE"     type="int8u"                              writable="false" optional="false" isNullable="false" reportable="true">CurrentMode</attribute>
+    <attribute side="server" code="0x0000" define="SUPPORTED_MODES" type="array" entryType="ModeOptionStruct" length="255">
+      <description>SupportedModes</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="CURRENT_MODE" type="int8u" reportable="true">
+      <description>CurrentMode</description>
+      <mandatoryConform/>
+    </attribute>
     <!-- Attribute OnMode with code 0x0003 is deprecated -->
 
     <!-- Commands -->
@@ -78,6 +84,7 @@ limitations under the License.
         On receipt of this command the device SHALL respond with a ChangeToModeResponse command.
       </description>
       <arg name="NewMode" type="int8u" optional="false"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x01" name="ChangeToModeResponse" disableDefaultResponse="true" optional="false">
@@ -86,6 +93,7 @@ limitations under the License.
       </description>
       <arg name="Status"     type="enum8"                   optional="false"/>
       <arg name="StatusText" type="char_string" lenght="64" optional="true"/>
+      <mandatoryConform/>
     </command>
   </cluster>
 

--- a/src/app/zap-templates/zcl/data-model/chip/rvc-run-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/rvc-run-mode-cluster.xml
@@ -73,8 +73,14 @@ limitations under the License.
     </features>
 
     <!-- Base data types -->
-    <attribute side="server" code="0x0000" define="SUPPORTED_MODES"  type="array" entryType="ModeOptionStruct" writable="false" optional="false" isNullable="false" length="255">SupportedModes</attribute>
-    <attribute side="server" code="0x0001" define="CURRENT_MODE"     type="int8u"                              writable="false" optional="false" isNullable="false" reportable="true">CurrentMode</attribute>
+    <attribute side="server" code="0x0000" define="SUPPORTED_MODES" type="array" entryType="ModeOptionStruct" length="255">
+      <description>SupportedModes</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="CURRENT_MODE" type="int8u" reportable="true">
+      <description>CurrentMode</description>
+      <mandatoryConform/>
+    </attribute>
     <!-- Attribute OnMode with code 0x0003 is deprecated -->
 
     <!-- Commands -->
@@ -84,6 +90,7 @@ limitations under the License.
         On receipt of this command the device SHALL respond with a ChangeToModeResponse command.
       </description>
       <arg name="NewMode" type="int8u" optional="false"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x01" name="ChangeToModeResponse" disableDefaultResponse="true" optional="false">
@@ -92,6 +99,7 @@ limitations under the License.
       </description>
       <arg name="Status"     type="enum8"                   optional="false"/>
       <arg name="StatusText" type="char_string" lenght="64" optional="true"/>
+      <mandatoryConform/>
     </command>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/scene.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/scene.xml
@@ -80,10 +80,19 @@ limitations under the License.
         <optionalConform/>
       </feature>
     </features>
-   
-    <attribute side="server" code="0x0000" define="LAST_CONFIGURED_BY" type="node_id" writable="false" isNullable="true" optional="true">LastConfiguredBy</attribute>
-    <attribute side="server" code="0x0001" define="SCENE_TABLE_SIZE" type="int16u" min="16" default="16" writable="false" optional="false">SceneTableSize</attribute>
-    <attribute side="server" code="0x0002" define="FABRIC_SCENE_INFO" type="array" entryType="SceneInfoStruct" writable="false" optional="false">FabricSceneInfo</attribute>
+    <attribute side="server" code="0x0000" define="LAST_CONFIGURED_BY" type="node_id" isNullable="true" optional="true">
+      <description>LastConfiguredBy</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="SCENE_TABLE_SIZE" type="int16u" min="16" default="16">
+      <description>SceneTableSize</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="FABRIC_SCENE_INFO" type="array" entryType="SceneInfoStruct">
+      <description>FabricSceneInfo</description>
+      <mandatoryConform/>
+    </attribute>
+    
     <command source="client" code="0x00" name="AddScene" response="AddSceneResponse" isFabricScoped="true" optional="false" cli="chip scenes add">
       <description>
         Add a scene to the scene table. Extension field sets are supported, and are inputed as '{"ClusterID": VALUE, "AttributeValueList":[{"AttributeID": VALUE, "Value*": VALUE}]}'
@@ -94,6 +103,7 @@ limitations under the License.
       <arg name="SceneName" type="char_string"/>
       <arg name="ExtensionFieldSets" type="ExtensionFieldSet" array="true"/>
       <access op="invoke" role="manage"/>
+      <mandatoryConform/>
     </command>
    
     <command source="client" code="0x01" name="ViewScene" response="ViewSceneResponse" isFabricScoped="true" optional="false" cli="chip scenes view">
@@ -102,6 +112,7 @@ limitations under the License.
       </description>
       <arg name="GroupID" type="group_id"/>
       <arg name="SceneID" type="int8u"/>
+      <mandatoryConform/>
     </command>
    
     <command source="client" code="0x02" name="RemoveScene" response="RemoveSceneResponse" isFabricScoped="true" optional="false" cli="chip scenes remove">
@@ -111,6 +122,7 @@ limitations under the License.
       <arg name="GroupID" type="group_id"/>
       <arg name="SceneID" type="int8u"/>
       <access op="invoke" role="manage"/>
+      <mandatoryConform/>
     </command>
     
     <command source="client" code="0x03" name="RemoveAllScenes" response="RemoveAllScenesResponse" isFabricScoped="true" optional="false" cli="chip scenes rmall">
@@ -119,6 +131,7 @@ limitations under the License.
       </description>
       <arg name="GroupID" type="group_id"/>
       <access op="invoke" role="manage"/>
+      <mandatoryConform/>
     </command>
     
     <command source="client" code="0x04" name="StoreScene" response="StoreSceneResponse" isFabricScoped="true" optional="false" cli="chip scenes store">
@@ -128,6 +141,7 @@ limitations under the License.
       <arg name="GroupID" type="group_id"/>
       <arg name="SceneID" type="int8u"/>
       <access op="invoke" role="manage"/>
+      <mandatoryConform/>
     </command>
     
     <command source="client" code="0x05" name="RecallScene" isFabricScoped="true" optional="false" cli="chip scenes recall">
@@ -137,6 +151,7 @@ limitations under the License.
       <arg name="GroupID" type="group_id"/>
       <arg name="SceneID" type="int8u"/>
       <arg name="TransitionTime" type="int32u" optional="true" isNullable="true"/>
+      <mandatoryConform/>
     </command>
    
     <command source="client" code="0x06" name="GetSceneMembership" response="GetSceneMembershipResponse" isFabricScoped="true" optional="false" cli="chip scenes get">
@@ -144,6 +159,7 @@ limitations under the License.
         Get an unused scene identifier when no commissioning tool is in the network, or for a commissioning tool to get the used scene identifiers within a certain group 
       </description>
       <arg name="GroupID" type="group_id"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x40" name="CopyScene" response="CopySceneResponse" isFabricScoped="true" optional="true" cli="chip scenes copy">
@@ -155,6 +171,7 @@ limitations under the License.
       <arg name="SceneIdentifierFrom" type="int8u"/>
       <arg name="GroupIdentifierTo" type="group_id"/>
       <arg name="SceneIdentifierTo" type="int8u"/>
+      <optionalConform/>
     </command>
     
     <command source="server" code="0x00" name="AddSceneResponse" optional="false" disableDefaultResponse="true">
@@ -164,6 +181,7 @@ limitations under the License.
       <arg name="Status" type="status"/>
       <arg name="GroupID" type="group_id"/>
       <arg name="SceneID" type="int8u"/>
+      <mandatoryConform/>
     </command>
     
     <command source="server" code="0x01" name="ViewSceneResponse" optional="false" disableDefaultResponse="true">
@@ -176,6 +194,7 @@ limitations under the License.
       <arg name="TransitionTime" type="int32u" optional="true"/>
       <arg name="SceneName" type="char_string" optional="true"/>
       <arg name="ExtensionFieldSets" type="ExtensionFieldSet" array="true" optional="true"/>
+      <mandatoryConform/>
     </command>
     
     <command source="server" code="0x02" name="RemoveSceneResponse" optional="false" disableDefaultResponse="true">
@@ -185,6 +204,7 @@ limitations under the License.
       <arg name="Status" type="status"/>
       <arg name="GroupID" type="group_id"/>
       <arg name="SceneID" type="int8u"/>
+      <mandatoryConform/>
     </command>
     
     <command source="server" code="0x03" name="RemoveAllScenesResponse" optional="false" disableDefaultResponse="true">
@@ -193,6 +213,7 @@ limitations under the License.
       </description>
       <arg name="Status" type="status"/>
       <arg name="GroupID" type="group_id"/>
+      <mandatoryConform/>
     </command>
     
     <command source="server" code="0x04" name="StoreSceneResponse" optional="false" disableDefaultResponse="true">
@@ -202,6 +223,7 @@ limitations under the License.
       <arg name="Status" type="status"/>
       <arg name="GroupID" type="group_id"/>
       <arg name="SceneID" type="int8u"/>
+      <mandatoryConform/>
     </command>
     
     <command source="server" code="0x06" name="GetSceneMembershipResponse" optional="false" disableDefaultResponse="true">
@@ -212,6 +234,7 @@ limitations under the License.
       <arg name="Capacity" type="int8u" isNullable="true"/>
       <arg name="GroupID" type="group_id"/>
       <arg name="SceneList" type="int8u" array="true" optional="true"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x40" name="CopySceneResponse" optional="true" disableDefaultResponse="true">
@@ -221,6 +244,9 @@ limitations under the License.
       <arg name="Status" type="status"/>
       <arg name="GroupIdentifierFrom" type="group_id"/>
       <arg name="SceneIdentifierFrom" type="int8u"/>
+      <mandatoryConform>
+        <command name="CopyScene"/>
+      </mandatoryConform>
     </command>
   </cluster>
 

--- a/src/app/zap-templates/zcl/data-model/chip/service-area-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/service-area-cluster.xml
@@ -96,19 +96,43 @@ limitations under the License.
     </features>
 
     <!-- Attributes -->
-    <attribute side="server" code="0x0000" define="SupportedAreas"      type="array"     entryType="AreaStruct"      writable="false" isNullable="false" optional="false">SupportedAreas</attribute>
-    <attribute side="server" code="0x0001" define="SupportedMaps"       type="array"     entryType="MapStruct"       writable="false" isNullable="false" optional="true" >SupportedMaps</attribute>
-    <attribute side="server" code="0x0002" define="SelectedAreas"       type="array"     entryType="int32u"          writable="false" isNullable="false" optional="false">SelectedAreas</attribute>
-    <attribute side="server" code="0x0003" define="CurrentArea"         type="int32u"                                writable="false" isNullable="true"  optional="true" >CurrentArea</attribute>
-    <attribute side="server" code="0x0004" define="EstimatedEndTime"    type="epoch_s"                               writable="false" isNullable="true"  optional="true" >EstimatedEndTime</attribute>
-    <attribute side="server" code="0x0005" define="Progress"            type="array"     entryType="ProgressStruct"  writable="false" isNullable="false" optional="true" >Progress</attribute>
-
+    <attribute side="server" code="0x0000" define="SupportedAreas" type="array" entryType="AreaStruct">
+      <description>SupportedAreas</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="SupportedMaps" type="array" entryType="MapStruct" optional="true">
+      <description>SupportedMaps</description>
+      <mandatoryConform>
+        <feature name="MAPS"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="SelectedAreas" type="array" entryType="int32u">
+      <description>SelectedAreas</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="CurrentArea" type="int32u" isNullable="true" optional="true">
+      <description>CurrentArea</description>
+    </attribute>
+    <attribute side="server" code="0x0004" define="EstimatedEndTime" type="epoch_s" isNullable="true" optional="true">
+      <description>EstimatedEndTime</description>
+      <optionalConform>
+        <attribute name="CurrentArea"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="Progress" type="array" entryType="ProgressStruct" optional="true">
+      <description>Progress</description>
+      <mandatoryConform>
+        <feature name="PROG"/>
+      </mandatoryConform>
+    </attribute>
+    
     <!-- Commands -->
     <command source="client" code="0x00" name="SelectAreas" response="SelectAreasResponse" optional="false">
       <description>
         Command used to select a set of device areas, where the device is to operate.
       </description>
       <arg name="NewAreas" type="int32u" array="true"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x01" name="SelectAreasResponse" disableDefaultResponse="true" optional="false">
@@ -117,6 +141,7 @@ limitations under the License.
       </description>
       <arg name="Status"     type="SelectAreasStatus"/>
       <arg name="StatusText" type="char_string" length="256"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x02" name="SkipArea" response="SkipAreaResponse" optional="true">
@@ -132,6 +157,9 @@ limitations under the License.
       </description>
       <arg name="Status"     type="SkipAreaStatus"/>
       <arg name="StatusText" type="char_string" length="256"/>
+      <mandatoryConform>
+        <command name="SkipArea"/>
+      </mandatoryConform>
     </command>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/smoke-co-alarm-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/smoke-co-alarm-cluster.xml
@@ -46,66 +46,131 @@ limitations under the License.
     </features>
 
     <!-- Attributes -->
-    <attribute side="server" code="0x0000" define="EXPRESSED_STATE" type="ExpressedStateEnum" writable="false" optional="false">ExpressedState</attribute>
-    <attribute side="server" code="0x0001" define="SMOKE_STATE" type="AlarmStateEnum" writable="false" optional="true">SmokeState</attribute>
-    <attribute side="server" code="0x0002" define="CO_STATE" type="AlarmStateEnum" writable="false" optional="true">COState</attribute>
-    <attribute side="server" code="0x0003" define="BATTERY_ALERT" type="AlarmStateEnum" writable="false" optional="false">BatteryAlert</attribute>
-    <attribute side="server" code="0x0004" define="DEVICE_MUTED" type="MuteStateEnum" writable="false" optional="true">DeviceMuted</attribute>
-    <attribute side="server" code="0x0005" define="TEST_IN_PROGRESS" type="boolean" writable="false" optional="false">TestInProgress</attribute>
-    <attribute side="server" code="0x0006" define="HARDWARE_FAULTALERT" type="boolean" writable="false" optional="false">HardwareFaultAlert</attribute>
-    <attribute side="server" code="0x0007" define="END_OF_SERVICEALERT" type="EndOfServiceEnum" writable="false" optional="false">EndOfServiceAlert</attribute>
-    <attribute side="server" code="0x0008" define="INTERCONNECT_SMOKE_ALARM" type="AlarmStateEnum" writable="false" optional="true">InterconnectSmokeAlarm</attribute>
-    <attribute side="server" code="0x0009" define="INTERCONNECT_CO_ALARM" type="AlarmStateEnum" writable="false" optional="true">InterconnectCOAlarm</attribute>
-    <attribute side="server" code="0x000A" define="CONTAMINATION_STATE" type="ContaminationStateEnum" writable="false" optional="true">ContaminationState</attribute>
+    <attribute side="server" code="0x0000" define="EXPRESSED_STATE" type="ExpressedStateEnum">
+      <description>ExpressedState</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="SMOKE_STATE" type="AlarmStateEnum" optional="true">
+      <description>SmokeState</description>
+      <mandatoryConform>
+        <feature name="SMOKE"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="CO_STATE" type="AlarmStateEnum" optional="true">
+      <description>COState</description>
+      <mandatoryConform>
+        <feature name="CO"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="BATTERY_ALERT" type="AlarmStateEnum">
+      <description>BatteryAlert</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0004" define="DEVICE_MUTED" type="MuteStateEnum" optional="true">
+      <description>DeviceMuted</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0005" define="TEST_IN_PROGRESS" type="boolean">
+      <description>TestInProgress</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0006" define="HARDWARE_FAULTALERT" type="boolean">
+      <description>HardwareFaultAlert</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0007" define="END_OF_SERVICEALERT" type="EndOfServiceEnum">
+      <description>EndOfServiceAlert</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0008" define="INTERCONNECT_SMOKE_ALARM" type="AlarmStateEnum" optional="true">
+      <description>InterconnectSmokeAlarm</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0009" define="INTERCONNECT_CO_ALARM" type="AlarmStateEnum" optional="true">
+      <description>InterconnectCOAlarm</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x000A" define="CONTAMINATION_STATE" type="ContaminationStateEnum" optional="true">
+      <description>ContaminationState</description>
+      <optionalConform>
+        <feature name="SMOKE"/>
+      </optionalConform>
+    </attribute>
     <attribute side="server" code="0x000B" define="SENSITIVITY_LEVEL" type="SensitivityEnum" min="0" max="2" writable="true" optional="true">
       <description>SmokeSensitivityLevel</description>
       <access op="write" role="manage"/>
+      <optionalConform>
+        <feature name="SMOKE"/>
+      </optionalConform>
     </attribute>
-    <attribute side="server" code="0x000C" define="EXPIRY_DATE" type="epoch_s" writable="false" optional="true">ExpiryDate</attribute>
-
+    <attribute side="server" code="0x000C" define="EXPIRY_DATE" type="epoch_s" optional="true">
+      <description>ExpiryDate</description>
+      <optionalConform/>
+    </attribute>
+    
     <!-- Commands -->
     <command source="client" code="0x00" name="SelfTestRequest" optional="true">
       <description>This command SHALL initiate a device self-test.</description>
+      <optionalConform/>
     </command>
 
     <!-- Events -->
     <event side="server" code="0x00" name="SmokeAlarm" priority="critical" optional="true">
       <description>This event SHALL be generated when SmokeState attribute changes to either Warning or Critical state.</description>
       <field id="0" name="AlarmSeverityLevel" type="AlarmStateEnum" />
+      <mandatoryConform>
+        <feature name="SMOKE"/>
+      </mandatoryConform>
     </event>
     <event side="server" code="0x01" name="COAlarm" priority="critical" optional="true">
       <description>This event SHALL be generated when COState attribute changes to either Warning or Critical state.</description>
       <field id="0" name="AlarmSeverityLevel" type="AlarmStateEnum" />
+      <mandatoryConform>
+        <feature name="CO"/>
+      </mandatoryConform>
     </event>
     <event side="server" code="0x02" name="LowBattery" priority="info" optional="false">
       <description>This event SHALL be generated when BatteryAlert attribute changes to either Warning or Critical state.</description>
       <field id="0" name="AlarmSeverityLevel" type="AlarmStateEnum" />
+      <mandatoryConform/>
     </event>
     <event side="server" code="0x03" name="HardwareFault" priority="info" optional="false">
       <description>This event SHALL be generated when the device detects a hardware fault that leads to setting HardwareFaultAlert to True.</description>
+      <mandatoryConform/>
     </event>
     <event side="server" code="0x04" name="EndOfService" priority="info" optional="false">
       <description>This event SHALL be generated when the EndOfServiceAlert is set to Expired.</description>
+      <mandatoryConform/>
     </event>
     <event side="server" code="0x05" name="SelfTestComplete" priority="info" optional="false">
       <description>This event SHALL be generated when the SelfTest completes, and the attribute TestInProgress changes to False.</description>
+      <mandatoryConform/>
     </event>
     <event side="server" code="0x06" name="AlarmMuted" priority="info" optional="true">
       <description>This event SHALL be generated when the DeviceMuted attribute changes to Muted.</description>
+      <optionalConform/>
     </event>
     <event side="server" code="0x07" name="MuteEnded" priority="info" optional="true">
       <description>This event SHALL be generated when DeviceMuted attribute changes to NotMuted.</description>
+      <optionalConform/>
     </event>
     <event side="server" code="0x08" name="InterconnectSmokeAlarm" priority="critical" optional="true">
       <description>This event SHALL be generated when the device hosting the server receives a smoke alarm from an interconnected sensor.</description>
       <field id="0" name="AlarmSeverityLevel" type="AlarmStateEnum" />
+      <optionalConform>
+        <feature name="SMOKE"/>
+      </optionalConform>
     </event>
     <event side="server" code="0x09" name="InterconnectCOAlarm" priority="critical" optional="true">
       <description>This event SHALL be generated when the device hosting the server receives a smoke alarm from an interconnected sensor.</description>
       <field id="0" name="AlarmSeverityLevel" type="AlarmStateEnum" />
+      <optionalConform>
+        <feature name="CO"/>
+      </optionalConform>
     </event>
     <event side="server" code="0x0A" name="AllClear" priority="info" optional="false">
       <description>This event SHALL be generated when ExpressedState attribute returns to Normal state.</description>
+      <mandatoryConform/>
     </event>
   </cluster>
 

--- a/src/app/zap-templates/zcl/data-model/chip/software-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/software-diagnostics-cluster.xml
@@ -37,20 +37,38 @@ limitations under the License.
       </feature>
     </features>
 
-    <attribute side="server" code="0x00" define="THREAD_METRICS" type="array" entryType="ThreadMetricsStruct" length="254" writable="false" optional="true">ThreadMetrics</attribute>
-    <attribute side="server" code="0x01" define="CURRENT_HEAP_FREE" type="int64u" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="true">CurrentHeapFree</attribute>
-    <attribute side="server" code="0x02" define="CURRENT_HEAP_USED" type="int64u" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="true">CurrentHeapUsed</attribute>
-    <attribute side="server" code="0x03" define="CURRENT_HEAP_HIGH_WATERMARK" type="int64u" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="true">CurrentHeapHighWatermark</attribute>
+    <attribute side="server" code="0x00" define="THREAD_METRICS" type="array" entryType="ThreadMetricsStruct" length="254" optional="true">
+      <description>ThreadMetrics</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x01" define="CURRENT_HEAP_FREE" type="int64u" optional="true">
+      <description>CurrentHeapFree</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x02" define="CURRENT_HEAP_USED" type="int64u" optional="true">
+      <description>CurrentHeapUsed</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x03" define="CURRENT_HEAP_HIGH_WATERMARK" type="int64u" optional="true">
+      <description>CurrentHeapHighWatermark</description>
+      <mandatoryConform>
+        <feature name="WTRMRK"/>
+      </mandatoryConform>
+    </attribute>
     <command source="client" code="0x00" name="ResetWatermarks" optional="true" cli="chip software_diagnostics resetwatermarks">
       <description>Reception of this command SHALL reset the values: The StackFreeMinimum field of the ThreadMetrics attribute, CurrentHeapHighWaterMark attribute.</description>
       <access op="invoke" privilege="manage"/>
+      <mandatoryConform>
+        <feature name="WTRMRK"/>
+      </mandatoryConform>
     </command>
     <event side="server" code="0x00" name="SoftwareFault" priority="info" optional="true">
       <description>Indicate the last software fault that has taken place on the Node.</description>
       <field id="0" name="ID" type="int64u"/>
       <field id="1" name="Name" type="char_string" length="8" optional="true"/>
       <field id="2" name="FaultRecording" type="octet_string" length="1024" optional="true"/>
-    </event>    
+      <optionalConform/>
+    </event>
   </cluster>
 
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/switch-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/switch-cluster.xml
@@ -78,38 +78,75 @@ Interactions with the switch device are exposed as attributes (for the latching 
       </feature>
     </features>
 
-    <attribute side="server" code="0x0000" define="NUMBER_OF_POSITIONS" type="int8u" writable="false" optional="false" default="2" min="2">NumberOfPositions</attribute>
-    <attribute side="server" code="0x0001" define="CURRENT_POSITION" type="int8u" writable="false" reportable="true" optional="false">CurrentPosition</attribute>
-    <attribute side="server" code="0x0002" define="MULTI_PRESS_MAX" type="int8u" writable="false" optional="true" default="2" min="2">MultiPressMax</attribute>
+    <attribute side="server" code="0x0000" define="NUMBER_OF_POSITIONS" type="int8u" default="2" min="2">
+      <description>NumberOfPositions</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="CURRENT_POSITION" type="int8u" reportable="true">
+      <description>CurrentPosition</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MULTI_PRESS_MAX" type="int8u" optional="true" default="2" min="2">
+      <description>MultiPressMax</description>
+      <mandatoryConform>
+        <feature name="MSM"/>
+      </mandatoryConform>
+    </attribute>
     <event side="server" code="0x00" priority="info" name="SwitchLatched" optional="true">
       <description>SwitchLatched</description>
       <field id="0" name="NewPosition" type="int8u" />
+      <mandatoryConform>
+        <feature name="LS"/>
+      </mandatoryConform>
     </event>
     <event side="server" code="0x01" priority="info" name="InitialPress" optional="true">
       <description>InitialPress</description>
       <field id="0" name="NewPosition" type="int8u" />
+      <mandatoryConform>
+        <feature name="MS"/>
+      </mandatoryConform>
     </event>
     <event side="server" code="0x02" priority="info" name="LongPress" optional="true">
       <description>LongPress</description>
       <field id="0" name="NewPosition" type="int8u" />
+      <mandatoryConform>
+        <feature name="MSL"/>
+      </mandatoryConform>
     </event>
     <event side="server" code="0x03" priority="info" name="ShortRelease" optional="true">
       <description>ShortRelease</description>
       <field id="0" name="PreviousPosition" type="int8u" />
+      <mandatoryConform>
+        <feature name="MSR"/>
+      </mandatoryConform>
     </event>
     <event side="server" code="0x04" priority="info" name="LongRelease" optional="true">
       <description>LongRelease</description>
       <field id="0" name="PreviousPosition" type="int8u" />
+      <mandatoryConform>
+        <feature name="MSL"/>
+      </mandatoryConform>
     </event>
     <event side="server" code="0x05" priority="info" name="MultiPressOngoing" optional="true">
       <description>MultiPressOngoing</description>
       <field id="0" name="NewPosition" type="int8u" />
       <field id="1" name="CurrentNumberOfPressesCounted" type="int8u" />
+      <mandatoryConform>
+        <andTerm>
+          <feature name="MSM"/>
+          <notTerm>
+            <feature name="AS"/>
+          </notTerm>
+        </andTerm>
+      </mandatoryConform>
     </event>
     <event side="server" code="0x06" priority="info" name="MultiPressComplete" optional="true">
       <description>MultiPressComplete</description>
       <field id="0" name="PreviousPosition" type="int8u" />
-      <field id="1" name="TotalNumberOfPressesCounted" type="int8u" />
+      <field id="1" name="TotalNumberOfPressesCounted" type="int8u"/>
+      <mandatoryConform>
+        <feature name="MSM"/>
+      </mandatoryConform>
     </event>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/target-navigator-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/target-navigator-cluster.xml
@@ -25,19 +25,27 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <globalAttribute side="either" code="0xFFFD" value="2"/> <!-- Revision   -->
     <description>This cluster provides an interface for UX navigation within a set of targets on a device or endpoint.</description>
-    <attribute side="server" code="0x0000" define="TARGET_NAVIGATOR_LIST"           type="array" entryType="TargetInfoStruct"    length="254" writable="false" optional="false">TargetList</attribute>
-    <attribute side="server" code="0x0001" define="TARGET_NAVIGATOR_CURRENT_TARGET" type="int8u" default="0"            min="0x00" max="0xFF" writable="false" optional="true">CurrentTarget</attribute>
-
+    <attribute side="server" code="0x0000" define="TARGET_NAVIGATOR_LIST" type="array" entryType="TargetInfoStruct" length="254">
+      <description>TargetList</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="TARGET_NAVIGATOR_CURRENT_TARGET" type="int8u" default="0" optional="true">
+      <description>CurrentTarget</description>
+      <optionalConform/>
+    </attribute>
+    
     <command source="client" code="0x00" name="NavigateTarget" response="NavigateTargetResponse" optional="false">
       <description>Upon receipt, this SHALL navigation the UX to the target identified.</description>
       <arg name="Target" type="int8u"/>
       <arg name="Data"   type="char_string" optional="true"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x01" name="NavigateTargetResponse" optional="false">
       <description>This command SHALL be generated in response to NavigateTarget commands.</description>
       <arg name="Status" type="StatusEnum"/>
       <arg name="Data"   type="char_string" optional="true"/>
+      <mandatoryConform/>
     </command>
 
     <event side="server" code="0x00" priority="info" name="TargetUpdated" optional="false">
@@ -45,6 +53,7 @@ limitations under the License.
       <field id="0" name="TargetList" array="true" type="TargetInfoStruct"  />
       <field id="1" name="CurrentTarget" type="int8u" />
       <field id="2" name="Data" length="900" type="octet_string" />
+      <optionalConform/>
     </event>
   </cluster>
 

--- a/src/app/zap-templates/zcl/data-model/chip/temperature-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/temperature-control-cluster.xml
@@ -40,17 +40,48 @@ limitations under the License.
       </feature>
     </features>
 
-    <attribute side="server" code="0x0000" define="TEMP_SETPOINT" type="temperature" writable="false" optional="true">TemperatureSetpoint</attribute>
-    <attribute side="server" code="0x0001" define="MIN_TEMP" type="temperature" writable="false" optional="true">MinTemperature</attribute>
-    <attribute side="server" code="0x0002" define="MAX_TEMP" type="temperature" writable="false" optional="true">MaxTemperature</attribute>
-    <attribute side="server" code="0x0003" define="STEP" type="temperature" writable="false" optional="true">Step</attribute>
-    <attribute side="server" code="0x0004" define="SELECTED_TEMP_LEVEL" type="int8u" writable="false" optional="true">SelectedTemperatureLevel</attribute>
-    <attribute side="server" code="0x0005" define="SUPPORTED_TEMP_LEVELS" type="array" entryType="char_string" writable="false" optional="true">SupportedTemperatureLevels</attribute>
+    <attribute side="server" code="0x0000" define="TEMP_SETPOINT" type="temperature" optional="true">
+      <description>TemperatureSetpoint</description>
+      <mandatoryConform>
+        <feature name="TN"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MIN_TEMP" type="temperature" optional="true">
+      <description>MinTemperature</description>
+      <mandatoryConform>
+        <feature name="TN"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MAX_TEMP" type="temperature" optional="true">
+      <description>MaxTemperature</description>
+      <mandatoryConform>
+        <feature name="TN"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="STEP" type="temperature" optional="true">
+      <description>Step</description>
+      <mandatoryConform>
+        <feature name="STEP"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="SELECTED_TEMP_LEVEL" type="int8u" optional="true">
+      <description>SelectedTemperatureLevel</description>
+      <mandatoryConform>
+        <feature name="TL"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="SUPPORTED_TEMP_LEVELS" type="array" entryType="char_string" optional="true">
+      <description>SupportedTemperatureLevels</description>
+      <mandatoryConform>
+        <feature name="TL"/>
+      </mandatoryConform>
+    </attribute>
 
     <command source="client" code="0x00" name="SetTemperature" optional="false">
-        <description>Set Temperature</description>
-        <arg name="TargetTemperature" type="temperature" min="MIN_TEMP" max="MAX_TEMP" optional="true"/>
-        <arg name="TargetTemperatureLevel" type="int8u" optional="true"/>
+      <description>Set Temperature</description>
+      <arg name="TargetTemperature" type="temperature" min="MIN_TEMP" max="MAX_TEMP" optional="true"/>
+      <arg name="TargetTemperatureLevel" type="int8u" optional="true"/>
+      <mandatoryConform/>
     </command>
   </cluster>
 

--- a/src/app/zap-templates/zcl/data-model/chip/temperature-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/temperature-measurement-cluster.xml
@@ -24,9 +24,21 @@ limitations under the License.
     <define>TEMPERATURE_MEASUREMENT_CLUSTER</define>
     <client tick="false" init="false">true</client>
     <server tick="false" init="false">true</server>
-    <attribute side="server" code="0x0000" define="TEMP_MEASURED_VALUE" type="temperature" min="0x954d" max="0x7fff" writable="false" isNullable="true" optional="false">MeasuredValue</attribute>
-    <attribute side="server" code="0x0001" define="TEMP_MIN_MEASURED_VALUE" type="temperature" min="0x954d" max="0x7ffe" writable="false" isNullable="true" default="0x8000" optional="false">MinMeasuredValue</attribute>
-    <attribute side="server" code="0x0002" define="TEMP_MAX_MEASURED_VALUE" type="temperature" min="0x954e" max="0x7fff" writable="false" isNullable="true" default="0x8000" optional="false">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="TEMP_TOLERANCE" type="int16u" min="0" max="0x0800" writable="false" default="0" optional="true">Tolerance</attribute>
+    <attribute side="server" code="0x0000" define="TEMP_MEASURED_VALUE" type="temperature" min="0x954d" isNullable="true">
+      <description>MeasuredValue</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="TEMP_MIN_MEASURED_VALUE" type="temperature" min="0x954d" max="0x7ffe" isNullable="true" default="0x8000">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="TEMP_MAX_MEASURED_VALUE" type="temperature" min="0x954e" isNullable="true" default="0x8000">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="TEMP_TOLERANCE" type="int16u" max="0x0800" default="0" optional="true">
+      <description>Tolerance</description>
+      <optionalConform/>
+    </attribute>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/thermostat-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/thermostat-cluster.xml
@@ -312,146 +312,368 @@ limitations under the License.
       </feature>
     </features>
     <!-- Attributes -->
-    <attribute side="server" code="0x0000" define="LOCAL_TEMPERATURE" type="temperature" reportable="true" isNullable="true">LocalTemperature</attribute>
-    <attribute side="server" code="0x0001" define="OUTDOOR_TEMPERATURE" type="temperature" optional="true" isNullable="true">OutdoorTemperature</attribute>
-    <attribute side="server" code="0x0002" define="THERMOSTAT_OCCUPANCY" type="OccupancyBitmap" default="1" optional="true" min="0x00" max="0x01">Occupancy</attribute>
-    <attribute side="server" code="0x0003" define="ABS_MIN_HEAT_SETPOINT_LIMIT" type="temperature" default="700" optional="true">AbsMinHeatSetpointLimit</attribute>
-    <attribute side="server" code="0x0004" define="ABS_MAX_HEAT_SETPOINT_LIMIT" type="temperature" default="3000" optional="true">AbsMaxHeatSetpointLimit</attribute>
-    <attribute side="server" code="0x0005" define="ABS_MIN_COOL_SETPOINT_LIMIT" type="temperature" default="1600" optional="true">AbsMinCoolSetpointLimit</attribute>
-    <attribute side="server" code="0x0006" define="ABS_MAX_COOL_SETPOINT_LIMIT" type="temperature" default="3200" optional="true">AbsMaxCoolSetpointLimit</attribute>
-    <attribute side="server" code="0x0007" define="PI_COOLING_DEMAND" type="int8u" min="0" max="100" reportable="true" optional="true">PICoolingDemand</attribute>
-    <attribute side="server" code="0x0008" define="PI_HEATING_DEMAND" type="int8u" min="0" max="100" reportable="true" optional="true">PIHeatingDemand</attribute>
+    <attribute side="server" code="0x0000" define="LOCAL_TEMPERATURE" type="temperature" reportable="true" isNullable="true">
+      <description>LocalTemperature</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="OUTDOOR_TEMPERATURE" type="temperature" optional="true" isNullable="true">
+      <description>OutdoorTemperature</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="THERMOSTAT_OCCUPANCY" type="OccupancyBitmap" default="1" optional="true" min="0x00" max="0x01">
+      <description>Occupancy</description>
+      <mandatoryConform>
+        <feature name="OCC"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="ABS_MIN_HEAT_SETPOINT_LIMIT" type="temperature" default="700" optional="true">
+      <description>AbsMinHeatSetpointLimit</description>
+      <optionalConform>
+        <feature name="HEAT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="ABS_MAX_HEAT_SETPOINT_LIMIT" type="temperature" default="3000" optional="true">
+      <description>AbsMaxHeatSetpointLimit</description>
+      <optionalConform>
+        <feature name="HEAT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="ABS_MIN_COOL_SETPOINT_LIMIT" type="temperature" default="1600" optional="true">
+      <description>AbsMinCoolSetpointLimit</description>
+      <optionalConform>
+        <feature name="COOL"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="ABS_MAX_COOL_SETPOINT_LIMIT" type="temperature" default="3200" optional="true">
+      <description>AbsMaxCoolSetpointLimit</description>
+      <optionalConform>
+        <feature name="COOL"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="PI_COOLING_DEMAND" type="int8u" min="0" max="100" reportable="true" optional="true">
+      <description>PICoolingDemand</description>
+      <optionalConform>
+        <feature name="COOL"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="PI_HEATING_DEMAND" type="int8u" min="0" max="100" reportable="true" optional="true">
+      <description>PIHeatingDemand</description>
+      <optionalConform>
+        <feature name="HEAT"/>
+      </optionalConform>
+    </attribute>
     <attribute side="server" code="0x0009" define="HVAC_SYSTEM_TYPE_CONFIGURATION" type="HVACSystemTypeBitmap" min="0x00" max="0x3F" writable="true" optional="true" default="0x00">
       <description>HVACSystemTypeConfiguration</description>
       <access op="write" privilege="manage"/>
+      <deprecateConform/>
     </attribute>
     <attribute side="server" code="0x0010" define="LOCAL_TEMPERATURE_CALIBRATION" type="int8s" min="-127" max="127" writable="true" default="0x00" optional="true">
       <description>LocalTemperatureCalibration</description>
       <access op="write" privilege="manage"/>
+      <optionalConform>
+        <notTerm>
+          <feature name="LTNE"/>
+        </notTerm>
+      </optionalConform>
     </attribute>
-    <attribute side="server" code="0x0011" define="OCCUPIED_COOLING_SETPOINT" type="temperature" min="-27315" max="0x7FFF" writable="true" default="2600" optional="true">OccupiedCoolingSetpoint</attribute>
-    <attribute side="server" code="0x0012" define="OCCUPIED_HEATING_SETPOINT" type="temperature" min="-27315" max="0x7FFF" writable="true" default="2000" optional="true">OccupiedHeatingSetpoint</attribute>
-    <attribute side="server" code="0x0013" define="UNOCCUPIED_COOLING_SETPOINT" type="temperature" min="-27315" max="0x7FFF" writable="true" default="2600" optional="true">UnoccupiedCoolingSetpoint</attribute>
-    <attribute side="server" code="0x0014" define="UNOCCUPIED_HEATING_SETPOINT" type="temperature" min="-27315" max="0x7FFF" writable="true" default="2000" optional="true">UnoccupiedHeatingSetpoint</attribute>
+    <attribute side="server" code="0x0011" define="OCCUPIED_COOLING_SETPOINT" type="temperature" min="-27315" max="0x7FFF" writable="true" default="2600" optional="true">
+      <description>OccupiedCoolingSetpoint</description>
+      <mandatoryConform>
+        <feature name="COOL"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0012" define="OCCUPIED_HEATING_SETPOINT" type="temperature" min="-27315" max="0x7FFF" writable="true" default="2000" optional="true">
+      <description>OccupiedHeatingSetpoint</description>
+      <mandatoryConform>
+        <feature name="HEAT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0013" define="UNOCCUPIED_COOLING_SETPOINT" type="temperature" min="-27315" max="0x7FFF" writable="true" default="2600" optional="true">
+      <description>UnoccupiedCoolingSetpoint</description>
+      <mandatoryConform>
+        <andTerm>
+          <feature name="COOL"/>
+          <feature name="OCC"/>
+        </andTerm>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0014" define="UNOCCUPIED_HEATING_SETPOINT" type="temperature" min="-27315" max="0x7FFF" writable="true" default="2000" optional="true">
+      <description>UnoccupiedHeatingSetpoint</description>
+      <mandatoryConform>
+        <andTerm>
+          <feature name="HEAT"/>
+          <feature name="OCC"/>
+        </andTerm>
+      </mandatoryConform>
+    </attribute>
     <attribute side="server" code="0x0015" define="MIN_HEAT_SETPOINT_LIMIT" type="temperature" min="-27315" max="0x7FFF" writable="true" default="700" optional="true">
       <description>MinHeatSetpointLimit</description>
       <access op="write" privilege="manage"/>
+      <optionalConform>
+        <feature name="HEAT"/>
+      </optionalConform>
     </attribute>
     <attribute side="server" code="0x0016" define="MAX_HEAT_SETPOINT_LIMIT" type="temperature" min="-27315" max="0x7FFF" writable="true" default="3000" optional="true">
       <description>MaxHeatSetpointLimit</description>
       <access op="write" privilege="manage"/>
+      <optionalConform>
+        <feature name="HEAT"/>
+      </optionalConform>
     </attribute>
     <attribute side="server" code="0x0017" define="MIN_COOL_SETPOINT_LIMIT" type="temperature" min="-27315" max="0x7FFF" writable="true" default="1600" optional="true">
       <description>MinCoolSetpointLimit</description>
       <access op="write" privilege="manage"/>
+      <optionalConform>
+        <feature name="COOL"/>
+      </optionalConform>
     </attribute>
     <attribute side="server" code="0x0018" define="MAX_COOL_SETPOINT_LIMIT" type="temperature" min="-27315" max="0x7FFF" writable="true" default="3200" optional="true">
       <description>MaxCoolSetpointLimit</description>
       <access op="write" privilege="manage"/>
+      <optionalConform>
+        <feature name="COOL"/>
+      </optionalConform>
     </attribute>
     <attribute side="server" code="0x0019" define="MIN_SETPOINT_DEAD_BAND" type="int8s" min="0" max="127" writable="true" default="25" optional="true">
       <description>MinSetpointDeadBand</description>
       <access op="write" privilege="manage"/>
+      <mandatoryConform>
+        <feature name="AUTO"/>
+      </mandatoryConform>
     </attribute>
     <attribute side="server" code="0x001A" define="REMOTE_SENSING" type="RemoteSensingBitmap" min="0x0" max="0x7" writable="true" default="0" optional="true">
       <description>RemoteSensing</description>
       <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
     <attribute side="server" code="0x001B" define="CONTROL_SEQUENCE_OF_OPERATION" type="ControlSequenceOfOperationEnum" min="0x0" max="0x5" writable="true" default="4">
       <description>ControlSequenceOfOperation</description>
       <access op="write" privilege="manage"/>
+      <mandatoryConform/>
     </attribute>
     <attribute side="server" code="0x001C" define="SYSTEM_MODE" type="SystemModeEnum" min="0x0" max="0x9" writable="true" default="1">
       <description>SystemMode</description>
       <access op="write" privilege="manage"/>
+      <mandatoryConform/>
     </attribute>
-    <attribute side="server" code="0x001E" define="THERMOSTAT_RUNNING_MODE" type="ThermostatRunningModeEnum" min="0x0" max="0x4" optional="true" default="0">ThermostatRunningMode</attribute>
-    <attribute side="server" code="0x0020" define="START_OF_WEEK" type="StartOfWeekEnum" min="0x0" max="0x6" optional="true">StartOfWeek</attribute>
-    <attribute side="server" code="0x0021" define="NUMBER_OF_WEEKLY_TRANSITIONS" type="int8u" optional="true" default="0">NumberOfWeeklyTransitions</attribute>
-    <attribute side="server" code="0x0022" define="NUMBER_OF_DAILY_TRANSITIONS" type="int8u" optional="true" default="0">NumberOfDailyTransitions</attribute>
+    <attribute side="server" code="0x001E" define="THERMOSTAT_RUNNING_MODE" type="ThermostatRunningModeEnum" min="0x0" max="0x4" optional="true" default="0">
+      <description>ThermostatRunningMode</description>
+      <optionalConform>
+        <feature name="AUTO"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0020" define="START_OF_WEEK" type="StartOfWeekEnum" min="0x0" max="0x6" optional="true">
+      <description>StartOfWeek</description>
+      <mandatoryConform>
+        <feature name="SCH"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0021" define="NUMBER_OF_WEEKLY_TRANSITIONS" type="int8u" optional="true" default="0">
+      <description>NumberOfWeeklyTransitions</description>
+      <mandatoryConform>
+        <feature name="SCH"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0022" define="NUMBER_OF_DAILY_TRANSITIONS" type="int8u" optional="true" default="0">
+      <description>NumberOfDailyTransitions</description>
+      <mandatoryConform>
+        <feature name="SCH"/>
+      </mandatoryConform>
+    </attribute>
     <attribute side="server" code="0x0023" define="TEMPERATURE_SETPOINT_HOLD" type="TemperatureSetpointHoldEnum" min="0x0" max="0x1" writable="true" default="0" optional="true">
       <description>TemperatureSetpointHold</description>
       <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
     <attribute side="server" code="0x0024" define="TEMPERATURE_SETPOINT_HOLD_DURATION" type="int16u" max="1440" writable="true" optional="true" isNullable="true">
       <description>TemperatureSetpointHoldDuration</description>
       <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
     <attribute side="server" code="0x0025" define="THERMOSTAT_PROGRAMMING_OPERATION_MODE" type="ProgrammingOperationModeBitmap" writable="true" default="0" optional="true" reportable="true" min="0x0" max="0x7">
       <description>ThermostatProgrammingOperationMode</description>
       <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
-    <attribute side="server" code="0x0029" define="THERMOSTAT_RUNNING_STATE" type="RelayStateBitmap" optional="true" min="0x0" max="0x7F">ThermostatRunningState</attribute>
-    <attribute side="server" code="0x0030" define="SETPOINT_CHANGE_SOURCE" type="SetpointChangeSourceEnum" optional="true" default="0" min="0x0" max="0x2">SetpointChangeSource</attribute>
-    <attribute side="server" code="0x0031" define="SETPOINT_CHANGE_AMOUNT" type="int16s" optional="true" isNullable="true">SetpointChangeAmount</attribute>
-    <attribute side="server" code="0x0032" define="SETPOINT_CHANGE_SOURCE_TIMESTAMP" type="epoch_s" optional="true" default="0">SetpointChangeSourceTimestamp</attribute>
+    <attribute side="server" code="0x0029" define="THERMOSTAT_RUNNING_STATE" type="RelayStateBitmap" optional="true" min="0x0" max="0x7F">
+      <description>ThermostatRunningState</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0030" define="SETPOINT_CHANGE_SOURCE" type="SetpointChangeSourceEnum" optional="true" default="0" min="0x0" max="0x2">
+      <description>SetpointChangeSource</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0031" define="SETPOINT_CHANGE_AMOUNT" type="int16s" optional="true" isNullable="true">
+      <description>SetpointChangeAmount</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0032" define="SETPOINT_CHANGE_SOURCE_TIMESTAMP" type="epoch_s" optional="true" default="0">
+      <description>SetpointChangeSourceTimestamp</description>
+      <optionalConform/>
+    </attribute>
     <attribute side="server" code="0x0034" define="OCCUPIED_SETBACK" type="int8u" writable="true" optional="true" isNullable="true" max="254">
       <description>OccupiedSetback</description>
       <access op="write" privilege="manage"/>
+      <mandatoryConform>
+        <feature name="SB"/>
+      </mandatoryConform>
     </attribute>
-    <attribute side="server" code="0x0035" define="OCCUPIED_SETBACK_MIN" type="int8u" optional="true" isNullable="true" max="254">OccupiedSetbackMin</attribute>
-    <attribute side="server" code="0x0036" define="OCCUPIED_SETBACK_MAX" type="int8u" optional="true" isNullable="true" max="254">OccupiedSetbackMax</attribute>
+    <attribute side="server" code="0x0035" define="OCCUPIED_SETBACK_MIN" type="int8u" optional="true" isNullable="true" max="254">
+      <description>OccupiedSetbackMin</description>
+      <mandatoryConform>
+        <feature name="SB"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0036" define="OCCUPIED_SETBACK_MAX" type="int8u" optional="true" isNullable="true" max="254">
+      <description>OccupiedSetbackMax</description>
+      <mandatoryConform>
+        <feature name="SB"/>
+      </mandatoryConform>
+    </attribute>
     <attribute side="server" code="0x0037" define="UNOCCUPIED_SETBACK" type="int8u" writable="true" optional="true" isNullable="true" max="254">
       <description>UnoccupiedSetback</description>
       <access op="write" privilege="manage"/>
+      <mandatoryConform>
+        <andTerm>
+          <feature name="SB"/>
+          <feature name="OCC"/>
+        </andTerm>
+      </mandatoryConform>
     </attribute>
-    <attribute side="server" code="0x0038" define="UNOCCUPIED_SETBACK_MIN" type="int8u" optional="true" isNullable="true" max="254">UnoccupiedSetbackMin</attribute>
-    <attribute side="server" code="0x0039" define="UNOCCUPIED_SETBACK_MAX" type="int8u" optional="true" isNullable="true" max="254">UnoccupiedSetbackMax</attribute>
+    <attribute side="server" code="0x0038" define="UNOCCUPIED_SETBACK_MIN" type="int8u" optional="true" isNullable="true" max="254">
+      <description>UnoccupiedSetbackMin</description>
+      <mandatoryConform>
+        <andTerm>
+          <feature name="SB"/>
+          <feature name="OCC"/>
+        </andTerm>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0039" define="UNOCCUPIED_SETBACK_MAX" type="int8u" optional="true" isNullable="true" max="254">
+      <description>UnoccupiedSetbackMax</description>
+      <mandatoryConform>
+        <andTerm>
+          <feature name="SB"/>
+          <feature name="OCC"/>
+        </andTerm>
+      </mandatoryConform>
+    </attribute>
     <attribute side="server" code="0x003A" define="EMERGENCY_HEAT_DELTA" type="int8u" writable="true" optional="true" default="0xFF" min="0" max="255">
       <description>EmergencyHeatDelta</description>
       <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
     <attribute side="server" code="0x0040" define="AC_TYPE" type="ACTypeEnum" min="0x0" max="0x4" writable="true" default="0" optional="true">
       <description>ACType</description>
       <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
     <attribute side="server" code="0x0041" define="AC_CAPACITY" type="int16u" writable="true" default="0" optional="true" max="65535">
       <description>ACCapacity</description>
       <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
     <attribute side="server" code="0x0042" define="AC_REFRIGERANT_TYPE" type="ACRefrigerantTypeEnum" min="0x0" max="0x3" writable="true" default="0" optional="true">
       <description>ACRefrigerantType</description>
       <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
     <attribute side="server" code="0x0043" define="AC_COMPRESSOR_TYPE" type="ACCompressorTypeEnum" min="0x0" max="0x3" writable="true" default="0" optional="true">
       <description>ACCompressorType</description>
       <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
     <attribute side="server" code="0x0044" define="AC_ERROR_CODE" type="ACErrorCodeBitmap" writable="true" default="0" optional="true">
       <description>ACErrorCode</description>
       <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
     <attribute side="server" code="0x0045" define="AC_LOUVER_POSITION" type="ACLouverPositionEnum" min="0x0" max="0x5" writable="true" default="0" optional="true">
       <description>ACLouverPosition</description>
       <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
-    <attribute side="server" code="0x0046" define="AC_COIL_TEMPERATURE" type="temperature" optional="true" isNullable="true">ACCoilTemperature</attribute>
+    <attribute side="server" code="0x0046" define="AC_COIL_TEMPERATURE" type="temperature" optional="true" isNullable="true">
+      <description>ACCoilTemperature</description>
+      <optionalConform/>
+    </attribute>
     <attribute side="server" code="0x0047" define="AC_CAPACITY_FORMAT" type="ACCapacityFormatEnum" min="0x00" max="0x00" writable="true" default="0" optional="true">
       <description>ACCapacityformat</description>
       <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
-    <attribute code="0x0048" side="server" type="array" entryType="PresetTypeStruct" define="PRESET_TYPES" optional="true">PresetTypes</attribute>
-    <attribute code="0x0049" side="server" type="array" entryType="ScheduleTypeStruct" define="SCHEDULE_TYPES" optional="true">ScheduleTypes</attribute>
-    <attribute code="0x004A" side="server" type="int8u" define="NUMBER_OF_PRESETS" default="0" optional="true">NumberOfPresets</attribute>
-    <attribute code="0x004B" side="server" type="int8u" define="NUMBER_OF_SCHEDULES" default="0" optional="true">NumberOfSchedules</attribute>
-    <attribute code="0x004C" side="server" type="int8u" define="NUMBER_OF_SCHEDULE_TRANSITIONS" default="0" optional="true">NumberOfScheduleTransitions</attribute>
-    <attribute code="0x004D" side="server" type="int8u" define="NUMBER_OF_SCHEDULE_TRANSITION_PER_DAY" isNullable="true" optional="true">NumberOfScheduleTransitionPerDay</attribute>
-    <attribute code="0x004E" side="server" type="octet_string" define="ACTIVE_PRESET_HANDLE" isNullable="true" length="16" optional="true">ActivePresetHandle</attribute>
-    <attribute code="0x004F" side="server" type="octet_string" define="ACTIVE_SCHEDULE_HANDLE" isNullable="true" length="16" optional="true">ActiveScheduleHandle</attribute>
+    <attribute code="0x0048" side="server" type="array" entryType="PresetTypeStruct" define="PRESET_TYPES" optional="true">
+      <description>PresetTypes</description>
+      <mandatoryConform>
+        <feature name="PRES"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute code="0x0049" side="server" type="array" entryType="ScheduleTypeStruct" define="SCHEDULE_TYPES" optional="true">
+      <description>ScheduleTypes</description>
+      <mandatoryConform>
+        <feature name="MSCH"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute code="0x004A" side="server" type="int8u" define="NUMBER_OF_PRESETS" default="0" optional="true">
+      <description>NumberOfPresets</description>
+      <mandatoryConform>
+        <feature name="PRES"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute code="0x004B" side="server" type="int8u" define="NUMBER_OF_SCHEDULES" default="0" optional="true">
+      <description>NumberOfSchedules</description>
+      <mandatoryConform>
+        <feature name="MSCH"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute code="0x004C" side="server" type="int8u" define="NUMBER_OF_SCHEDULE_TRANSITIONS" default="0" optional="true">
+      <description>NumberOfScheduleTransitions</description>
+      <mandatoryConform>
+        <feature name="MSCH"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute code="0x004D" side="server" type="int8u" define="NUMBER_OF_SCHEDULE_TRANSITION_PER_DAY" isNullable="true" optional="true">
+      <description>NumberOfScheduleTransitionPerDay</description>
+      <mandatoryConform>
+        <feature name="MSCH"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute code="0x004E" side="server" type="octet_string" define="ACTIVE_PRESET_HANDLE" isNullable="true" length="16" optional="true">
+      <description>ActivePresetHandle</description>
+      <mandatoryConform>
+        <feature name="PRES"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute code="0x004F" side="server" type="octet_string" define="ACTIVE_SCHEDULE_HANDLE" isNullable="true" length="16" optional="true">
+      <description>ActiveScheduleHandle</description>
+      <mandatoryConform>
+        <feature name="MSCH"/>
+      </mandatoryConform>
+    </attribute>
     <attribute code="0x0050" side="server" type="array" entryType="PresetStruct" define="PRESETS" writable="true" optional="true" mustUseAtomicWrite="true">
       <description>Presets</description>
       <access op="write" privilege="manage"/>
+      <mandatoryConform>
+        <feature name="PRES"/>
+      </mandatoryConform>
     </attribute>
     <attribute code="0x0051" side="server" type="array" entryType="ScheduleStruct" define="SCHEDULES" writable="true" optional="true" mustUseAtomicWrite="true">
       <description>Schedules</description>
       <access op="write" privilege="manage"/>
+      <mandatoryConform>
+        <feature name="MSCH"/>
+      </mandatoryConform>
     </attribute>
-    <attribute code="0x0052" side="server" type="epoch_s" define="SETPOINT_HOLD_EXPIRY_TIMESTAMP" optional="true" isNullable="true">SetpointHoldExpiryTimestamp</attribute>
+    <attribute code="0x0052" side="server" type="epoch_s" define="SETPOINT_HOLD_EXPIRY_TIMESTAMP" optional="true" isNullable="true">
+      <description>SetpointHoldExpiryTimestamp</description>
+      <optionalConform/>
+    </attribute>
     <!-- Client Commands -->
     <command source="client" code="0x00" name="SetpointRaiseLower" optional="false">
       <description>Upon receipt, the attributes for the indicated setpoint(s) SHALL have the amount specified in the Amount field added to them.</description>
       <arg id="0" name="Mode" type="SetpointRaiseLowerModeEnum" min="0x0" max="0x2"/>
       <arg id="1" name="Amount" type="int8s"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x01" name="SetWeeklySchedule" optional="true">
@@ -461,27 +683,42 @@ limitations under the License.
       <arg id="1" name="DayOfWeekForSequence" type="ScheduleDayOfWeekBitmap" min="0x0" max="0xFF"/>
       <arg id="2" name="ModeForSequence" type="ScheduleModeBitmap" min="0x0" max="0x3"/>
       <arg id="3" name="Transitions" type="WeeklyScheduleTransitionStruct" array="true" length="10"/>
+      <mandatoryConform>
+        <feature name="SCH"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x02" name="GetWeeklySchedule" response="GetWeeklyScheduleResponse" optional="true">
       <description>The Current Weekly Schedule Command is sent from the server in response to the Get Weekly Schedule Command.</description>
       <arg id="0" name="DaysToReturn" type="ScheduleDayOfWeekBitmap" min="0x0" max="0xFF"/>
       <arg id="1" name="ModeToReturn" type="ScheduleModeBitmap" min="0x0" max="0x3"/>
+      <mandatoryConform>
+        <feature name="SCH"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x03" name="ClearWeeklySchedule" optional="true">
       <description>This command is used to clear the weekly schedule.</description>
       <access op="invoke" privilege="manage"/>
+      <mandatoryConform>
+        <feature name="SCH"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x05" name="SetActiveScheduleRequest" optional="true">
       <description>Upon receipt, if the Schedules attribute contains a ScheduleStruct whose ScheduleHandle field matches the value of the ScheduleHandle field, the server SHALL set the thermostat&apos;s ActiveScheduleHandle attribute to the value of the ScheduleHandle field.</description>
       <arg id="0" name="ScheduleHandle" type="octet_string" length="16"/>
+      <mandatoryConform>
+        <feature name="MSCH"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x06" name="SetActivePresetRequest" optional="true">
       <description>ID</description>
       <arg id="0" name="PresetHandle" type="octet_string" length="16" isNullable="true"/>
+      <mandatoryConform>
+        <feature name="PRES"/>
+      </mandatoryConform>
     </command>
 
     <!-- Server Commands/Responses -->
@@ -491,6 +728,9 @@ limitations under the License.
       <arg id="1" name="DayOfWeekForSequence" type="ScheduleDayOfWeekBitmap" min="0x0" max="0xFF"/>
       <arg id="2" name="ModeForSequence" type="ScheduleModeBitmap" min="0x0" max="0x3"/>
       <arg id="3" name="Transitions" type="WeeklyScheduleTransitionStruct" array="true" length="10"/>
+      <mandatoryConform>
+        <feature name="SCH"/>
+      </mandatoryConform>
     </command>
 
     <command code="0xFD" source="server" name="AtomicResponse" optional="true">

--- a/src/app/zap-templates/zcl/data-model/chip/thermostat-user-interface-configuration-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/thermostat-user-interface-configuration-cluster.xml
@@ -29,18 +29,23 @@ limitations under the License.
 
     <globalAttribute side="either" code="0xFFFD" value="2"/>
 
-    <attribute side="server" code="0x0000" define="TEMPERATURE_DISPLAY_MODE" type="TemperatureDisplayModeEnum" min="0x00" max="0x01" writable="true" default="0x00" optional="false">TemperatureDisplayMode</attribute>
-
-    <attribute side="server" code="0x0001" define="KEYPAD_LOCKOUT" type="KeypadLockoutEnum" min="0x00" max="0x05" writable="true" default="0x00" optional="false">
+    <attribute side="server" code="0x0000" define="TEMPERATURE_DISPLAY_MODE" type="TemperatureDisplayModeEnum" min="0x00" max="0x01" writable="true" default="0x00">
+      <description>TemperatureDisplayMode</description>
+      <mandatoryConform/>
+    </attribute>
+    
+    <attribute side="server" code="0x0001" define="KEYPAD_LOCKOUT" type="KeypadLockoutEnum" min="0x00" max="0x05" writable="true" default="0x00">
       <description>KeypadLockout</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <mandatoryConform/>
     </attribute>
 
     <attribute side="server" code="0x0002" define="SCHEDULE_PROGRAMMING_VISIBILITY" type="ScheduleProgrammingVisibilityEnum" min="0x00" max="0x01" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">
       <description>ScheduleProgrammingVisibility</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <optionalConform/>
     </attribute>
   </cluster>
 

--- a/src/app/zap-templates/zcl/data-model/chip/thread-border-router-management-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/thread-border-router-management-cluster.xml
@@ -33,31 +33,52 @@ limitations under the License.
 
     <globalAttribute code="0xFFFD" side="either" value="1"/>
 
-    <attribute side="server" code="0x0000" apiMaturity="provisional" define="BORDER_ROUTER_NAME" type="char_string" length="63">BorderRouterName</attribute>
+    <attribute side="server" code="0x0000" apiMaturity="provisional" define="BORDER_ROUTER_NAME" type="char_string" length="63">
+      <description>BorderRouterName</description>
+      <mandatoryConform/>
+    </attribute>
 
-    <attribute side="server" code="0x0001" apiMaturity="provisional" define="BORDER_AGENT_ID" type="octet_string">BorderAgentID</attribute>
+    <attribute side="server" code="0x0001" apiMaturity="provisional" define="BORDER_AGENT_ID" type="octet_string">
+      <description>BorderAgentID</description>
+      <mandatoryConform/>
+    </attribute>
+    
+    <attribute side="server" code="0x0002" apiMaturity="provisional" define="THREAD_VERSION" type="int16u">
+      <description>ThreadVersion</description>
+      <mandatoryConform/>
+    </attribute>
 
-    <attribute side="server" code="0x0002" apiMaturity="provisional" define="THREAD_VERSION" type="int16u">ThreadVersion</attribute>
+    <attribute side="server" code="0x0003" apiMaturity="provisional" define="INTERFACE_ENABLED" type="boolean" default="0">
+      <description>InterfaceEnabled</description>
+      <mandatoryConform/>
+    </attribute>
 
-    <attribute side="server" code="0x0003" apiMaturity="provisional" define="INTERFACE_ENABLED" type="boolean" default="0">InterfaceEnabled</attribute>
+    <attribute side="server" code="0x0004" apiMaturity="provisional" define="ACTIVE_DATASET_TIMESTAMP" type="int64u" isNullable="true">
+      <description>ActiveDatasetTimestamp</description>
+      <mandatoryConform/>
+    </attribute>
 
-    <attribute side="server" code="0x0004" apiMaturity="provisional" define="ACTIVE_DATASET_TIMESTAMP" type="int64u" isNullable="true">ActiveDatasetTimestamp</attribute>
-
-    <attribute side="server" code="0x0005" apiMaturity="provisional" define="PENDING_DATASET_TIMESTAMP" type="int64u" isNullable="true">PendingDatasetTimestamp</attribute>
-
+    <attribute side="server" code="0x0005" apiMaturity="provisional" define="PENDING_DATASET_TIMESTAMP" type="int64u" isNullable="true">
+      <description>PendingDatasetTimestamp</description>
+      <mandatoryConform/>
+    </attribute>
+    
     <command source="client" code="0x00" apiMaturity="provisional" name="GetActiveDatasetRequest" response="DatasetResponse" optional="false">
       <description>Command to request the active operational dataset of the Thread network to which the border router is connected. This command must be sent over a valid CASE session</description>
       <access op="invoke" privilege="manage"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x01" apiMaturity="provisional" name="GetPendingDatasetRequest" response="DatasetResponse" optional="false">
       <description>Command to request the pending dataset of the Thread network to which the border router is connected. This command must be sent over a valid CASE session</description>
       <access op="invoke" privilege="manage"/>
+      <mandatoryConform/>
     </command>
 
-    <command source="server" code="0x02" apiMaturity="provisional" name="DatasetResponse" optional="false">
+   <command source="server" code="0x02" apiMaturity="provisional" name="DatasetResponse" optional="false">
       <description>Generated response to GetActiveDatasetRequest or GetPendingDatasetRequest commands.</description>
       <arg name="Dataset" type="octet_string" length="254"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x03" apiMaturity="provisional" name="SetActiveDatasetRequest" optional="false">
@@ -65,12 +86,16 @@ limitations under the License.
       <arg name="ActiveDataset" type="octet_string" length="254"/>
       <arg name="Breadcrumb" type="int64u" optional="true"/>
       <access op="invoke" privilege="manage"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x04" apiMaturity="provisional" name="SetPendingDatasetRequest" optional="true">
       <description>Command set or update the pending Dataset of the Thread network to which the Border Router is connected.</description>
       <arg name="PendingDataset" type="octet_string" length="254"/>
       <access op="invoke" privilege="manage"/>
+      <mandatoryConform>
+        <feature name="PC"/>
+      </mandatoryConform>
     </command>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/thread-network-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/thread-network-diagnostics-cluster.xml
@@ -107,82 +107,362 @@ limitations under the License.
         <optionalConform/>
       </feature>
     </features>
-
-    <attribute side="server" code="0x00" define="CHANNEL" type="int16u" min="0x00" max="0xFFFF" writable="false" isNullable="true" optional="false">Channel</attribute>
-    <attribute side="server" code="0x01" define="ROUTING_ROLE" type="RoutingRoleEnum" writable="false" isNullable="true" optional="false">RoutingRole</attribute>
-    <attribute side="server" code="0x02" define="NETWORK_NAME" type="char_string" length="16" writable="false" default="" isNullable="true" optional="false">NetworkName</attribute>
-    <attribute side="server" code="0x03" define="DIAG_PAN_ID" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x0000" isNullable="true" optional="false">PanId</attribute>
-    <attribute side="server" code="0x04" define="DIAG_EXTENDED_PAN_ID" type="int64u" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" isNullable="true" optional="false">ExtendedPanId</attribute>
-    <attribute side="server" code="0x05" define="MESH_LOCAL_PREFIX" type="octet_string" length="17" writable="false" isNullable="true" optional="false">MeshLocalPrefix</attribute>
-    <attribute side="server" code="0x06" define="DIAG_OVERRUN_COUNT" type="int64u" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="true">OverrunCount</attribute>
-    <attribute side="server" code="0x07" define="NEIGHBOR_TABLE" type="array" entryType="NeighborTableStruct" length="254" writable="false" optional="false">NeighborTable</attribute>
-    <attribute side="server" code="0x08" define="ROUTE_TABLE" type="array" entryType="RouteTableStruct" length="254" writable="false" optional="false">RouteTable</attribute>
-    <attribute side="server" code="0x09" define="PARTITION_ID" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" isNullable="true" optional="false">PartitionId</attribute>
-    <attribute side="server" code="0x0A" define="WEIGHTING" type="int16u" max="0xFF" writable="false"  isNullable="true" optional="false">Weighting</attribute>
-    <attribute side="server" code="0x0B" define="DATA_VERSION" type="int16u" max="0xFF" writable="false"  isNullable="true" optional="false">DataVersion</attribute>
-    <attribute side="server" code="0x0C" define="STABLE_DATA_VERSION" type="int16u" max="0xFF" writable="false"  isNullable="true" optional="false">StableDataVersion</attribute>
-    <attribute side="server" code="0x0D" define="LEADER_ROUTER_ID" type="int8u" min="0x00" max="62" writable="false"  isNullable="true" optional="false">LeaderRouterId</attribute>
-    <attribute side="server" code="0x0E" define="DETACHED_ROLE_COUNT" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">DetachedRoleCount</attribute>
-    <attribute side="server" code="0x0F" define="CHILD_ROLE_COUNT" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">ChildRoleCount</attribute>
-    <attribute side="server" code="0x10" define="ROUTER_ROLE_COUNT" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">RouterRoleCount</attribute>
-    <attribute side="server" code="0x11" define="LEADER_ROLE_COUNT" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">LeaderRoleCount</attribute>
-    <attribute side="server" code="0x12" define="ATTACH_ATTEMPT_COUNT" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">AttachAttemptCount</attribute>
-    <attribute side="server" code="0x13" define="PARTITION_ID_CHANGE_COUNT" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">PartitionIdChangeCount</attribute>
-    <attribute side="server" code="0x14" define="BETTER_PARTITION_ATTACH_ATTEMPT_COUNT" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">BetterPartitionAttachAttemptCount</attribute>
-    <attribute side="server" code="0x15" define="PARENT_CHANGE_COUNT" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">ParentChangeCount</attribute>
-    <attribute side="server" code="0x16" define="TX_TOTAL_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">TxTotalCount</attribute>
-    <attribute side="server" code="0x17" define="TX_UNICAST_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">TxUnicastCount</attribute>
-    <attribute side="server" code="0x18" define="TX_BROADCAST_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">TxBroadcastCount</attribute>
-    <attribute side="server" code="0x19" define="TX_ACK_REQUESTED_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">TxAckRequestedCount</attribute>
-    <attribute side="server" code="0x1A" define="TX_ACKED_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">TxAckedCount</attribute>
-    <attribute side="server" code="0x1B" define="TX_NO_ACK_REQUESTED_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">TxNoAckRequestedCount</attribute>
-    <attribute side="server" code="0x1C" define="TX_DATA_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">TxDataCount</attribute>
-    <attribute side="server" code="0x1D" define="TX_DATA_POLL_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">TxDataPollCount</attribute>
-    <attribute side="server" code="0x1E" define="TX_BEACON_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">TxBeaconCount</attribute>
-    <attribute side="server" code="0x1F" define="TX_BEACON_REQUEST_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">TxBeaconRequestCount</attribute>
-    <attribute side="server" code="0x20" define="TX_OTHER_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">TxOtherCount</attribute>
-    <attribute side="server" code="0x21" define="TX_RETRY_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">TxRetryCount</attribute>
-    <attribute side="server" code="0x22" define="TX_DIRECT_MAX_RETRY_EXPIRY_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">TxDirectMaxRetryExpiryCount</attribute>
-    <attribute side="server" code="0x23" define="TX_INDIRECT_MAX_RETRY_EXPIRY_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">TxIndirectMaxRetryExpiryCount</attribute>
-    <attribute side="server" code="0x24" define="TX_ERR_CCA_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">TxErrCcaCount</attribute>
-    <attribute side="server" code="0x25" define="TX_ERR_ABORT_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">TxErrAbortCount</attribute>
-    <attribute side="server" code="0x26" define="TX_ERR_BUSY_CHANNEL_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">TxErrBusyChannelCount</attribute>
-    <attribute side="server" code="0x27" define="RX_TOTAL_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">RxTotalCount</attribute>
-    <attribute side="server" code="0x28" define="RX_UNICAST_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">RxUnicastCount</attribute>
-    <attribute side="server" code="0x29" define="RX_BROADCAST_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">RxBroadcastCount</attribute>
-    <attribute side="server" code="0x2A" define="RX_DATA_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">RxDataCount</attribute>
-    <attribute side="server" code="0x2B" define="RX_DATA_POLL_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">RxDataPollCount</attribute>
-    <attribute side="server" code="0x2C" define="RX_BEACON_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">RxBeaconCount</attribute>
-    <attribute side="server" code="0x2D" define="RX_BEACON_REQUEST_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">RxBeaconRequestCount</attribute>
-    <attribute side="server" code="0x2E" define="RX_OTHER_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">RxOtherCount</attribute>
-    <attribute side="server" code="0x2F" define="RX_ADDRESS_FILTERED_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">RxAddressFilteredCount</attribute>
-    <attribute side="server" code="0x30" define="RX_DESTADDR_FILTERED_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">RxDestAddrFilteredCount</attribute>
-    <attribute side="server" code="0x31" define="RX_DUPLICATED_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">RxDuplicatedCount</attribute>
-    <attribute side="server" code="0x32" define="RX_ERR_NO_FRAME_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">RxErrNoFrameCount</attribute>
-    <attribute side="server" code="0x33" define="RX_ERR_UNKNOWN_NEIGHBOR_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">RxErrUnknownNeighborCount</attribute>
-    <attribute side="server" code="0x34" define="RX_ERR_INVALID_SRC_ADDR_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">RxErrInvalidSrcAddrCount</attribute>
-    <attribute side="server" code="0x35" define="RX_ERR_SEC_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">RxErrSecCount</attribute>
-    <attribute side="server" code="0x36" define="RX_ERR_FCS_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">RxErrFcsCount</attribute>
-    <attribute side="server" code="0x37" define="RX_ERR_OTHER_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" optional="true">RxErrOtherCount</attribute>
-    <attribute side="server" code="0x38" define="ACTIVE_TIMESTAMP" type="int64u" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" isNullable="true" optional="true">ActiveTimestamp</attribute>
-    <attribute side="server" code="0x39" define="PENDING_TIMESTAMP" type="int64u" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" isNullable="true" optional="true">PendingTimestamp</attribute>
-    <attribute side="server" code="0x3A" define="DELAY" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x0000" isNullable="true" optional="true">Delay</attribute>
-    <attribute side="server" code="0x3B" define="SECURITY_POLICY" type="SecurityPolicy" writable="false" isNullable="true" optional="false">SecurityPolicy</attribute>
-    <attribute side="server" code="0x3C" define="DIAG_CHANNEL_MASK" type="octet_string" length="4" writable="false" isNullable="true" optional="false">ChannelPage0Mask</attribute>
-    <attribute side="server" code="0x3D" define="OPERATIONAL_DATASET_COMPONENTS" type="OperationalDatasetComponents" writable="false" isNullable="true" optional="false">OperationalDatasetComponents</attribute>
-    <attribute side="server" code="0x3E" define="ACTIVE_THREAD_NETWORK_FAULTS" type="array" entryType="NetworkFaultEnum" length="4" writable="false" optional="false">ActiveNetworkFaultsList</attribute>
+    
+    <attribute side="server" code="0x00" define="CHANNEL" type="int16u" isNullable="true">
+      <description>Channel</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x01" define="ROUTING_ROLE" type="RoutingRoleEnum" isNullable="true">
+      <description>RoutingRole</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x02" define="NETWORK_NAME" type="char_string" length="16" isNullable="true">
+      <description>NetworkName</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x03" define="DIAG_PAN_ID" type="int16u" isNullable="true">
+      <description>PanId</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x04" define="DIAG_EXTENDED_PAN_ID" type="int64u" isNullable="true">
+      <description>ExtendedPanId</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x05" define="MESH_LOCAL_PREFIX" type="octet_string" length="17" isNullable="true">
+      <description>MeshLocalPrefix</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x06" define="DIAG_OVERRUN_COUNT" type="int64u" default="0x0000000000000000" optional="true">
+      <description>OverrunCount</description>
+      <mandatoryConform>
+        <feature name="ERRCNT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x07" define="NEIGHBOR_TABLE" type="array" entryType="NeighborTableStruct" length="254">
+      <description>NeighborTable</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x08" define="ROUTE_TABLE" type="array" entryType="RouteTableStruct" length="254">
+      <description>RouteTable</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x09" define="PARTITION_ID" type="int32u" isNullable="true">
+      <description>PartitionId</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0A" define="WEIGHTING" type="int16u" max="0xFF" isNullable="true">
+      <description>Weighting</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0B" define="DATA_VERSION" type="int16u" max="0xFF" isNullable="true">
+      <description>DataVersion</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0C" define="STABLE_DATA_VERSION" type="int16u" max="0xFF" isNullable="true">
+      <description>StableDataVersion</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0D" define="LEADER_ROUTER_ID" type="int8u" max="62" isNullable="true">
+      <description>LeaderRouterId</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0E" define="DETACHED_ROLE_COUNT" type="int16u" default="0x0000" optional="true">
+      <description>DetachedRoleCount</description>
+      <optionalConform>
+        <feature name="MLECNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0F" define="CHILD_ROLE_COUNT" type="int16u" default="0x0000" optional="true">
+      <description>ChildRoleCount</description>
+      <optionalConform>
+        <feature name="MLECNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x10" define="ROUTER_ROLE_COUNT" type="int16u" default="0x0000" optional="true">
+      <description>RouterRoleCount</description>
+      <optionalConform>
+        <feature name="MLECNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x11" define="LEADER_ROLE_COUNT" type="int16u" default="0x0000" optional="true">
+      <description>LeaderRoleCount</description>
+      <optionalConform>
+        <feature name="MLECNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x12" define="ATTACH_ATTEMPT_COUNT" type="int16u" default="0x0000" optional="true">
+      <description>AttachAttemptCount</description>
+      <optionalConform>
+        <feature name="MLECNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x13" define="PARTITION_ID_CHANGE_COUNT" type="int16u" default="0x0000" optional="true">
+      <description>PartitionIdChangeCount</description>
+      <optionalConform>
+        <feature name="MLECNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x14" define="BETTER_PARTITION_ATTACH_ATTEMPT_COUNT" type="int16u" default="0x0000" optional="true">
+      <description>BetterPartitionAttachAttemptCount</description>
+      <optionalConform>
+        <feature name="MLECNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x15" define="PARENT_CHANGE_COUNT" type="int16u" default="0x0000" optional="true">
+      <description>ParentChangeCount</description>
+      <optionalConform>
+        <feature name="MLECNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x16" define="TX_TOTAL_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>TxTotalCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x17" define="TX_UNICAST_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>TxUnicastCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x18" define="TX_BROADCAST_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>TxBroadcastCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x19" define="TX_ACK_REQUESTED_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>TxAckRequestedCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x1A" define="TX_ACKED_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>TxAckedCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x1B" define="TX_NO_ACK_REQUESTED_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>TxNoAckRequestedCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x1C" define="TX_DATA_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>TxDataCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x1D" define="TX_DATA_POLL_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>TxDataPollCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x1E" define="TX_BEACON_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>TxBeaconCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x1F" define="TX_BEACON_REQUEST_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>TxBeaconRequestCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x20" define="TX_OTHER_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>TxOtherCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x21" define="TX_RETRY_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>TxRetryCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x22" define="TX_DIRECT_MAX_RETRY_EXPIRY_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>TxDirectMaxRetryExpiryCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x23" define="TX_INDIRECT_MAX_RETRY_EXPIRY_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>TxIndirectMaxRetryExpiryCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x24" define="TX_ERR_CCA_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>TxErrCcaCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x25" define="TX_ERR_ABORT_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>TxErrAbortCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x26" define="TX_ERR_BUSY_CHANNEL_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>TxErrBusyChannelCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x27" define="RX_TOTAL_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>RxTotalCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x28" define="RX_UNICAST_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>RxUnicastCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x29" define="RX_BROADCAST_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>RxBroadcastCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x2A" define="RX_DATA_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>RxDataCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x2B" define="RX_DATA_POLL_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>RxDataPollCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x2C" define="RX_BEACON_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>RxBeaconCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x2D" define="RX_BEACON_REQUEST_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>RxBeaconRequestCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x2E" define="RX_OTHER_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>RxOtherCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x2F" define="RX_ADDRESS_FILTERED_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>RxAddressFilteredCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x30" define="RX_DESTADDR_FILTERED_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>RxDestAddrFilteredCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x31" define="RX_DUPLICATED_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>RxDuplicatedCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x32" define="RX_ERR_NO_FRAME_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>RxErrNoFrameCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x33" define="RX_ERR_UNKNOWN_NEIGHBOR_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>RxErrUnknownNeighborCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x34" define="RX_ERR_INVALID_SRC_ADDR_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>RxErrInvalidSrcAddrCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x35" define="RX_ERR_SEC_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>RxErrSecCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x36" define="RX_ERR_FCS_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>RxErrFcsCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x37" define="RX_ERR_OTHER_COUNT" type="int32u" default="0x0000" optional="true">
+      <description>RxErrOtherCount</description>
+      <optionalConform>
+        <feature name="MACCNT"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x38" define="ACTIVE_TIMESTAMP" type="int64u" default="0x0000000000000000" isNullable="true" optional="true">
+      <description>ActiveTimestamp</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x39" define="PENDING_TIMESTAMP" type="int64u" default="0x0000000000000000" isNullable="true" optional="true">
+      <description>PendingTimestamp</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x3A" define="DELAY" type="int32u" default="0x0000" isNullable="true" optional="true">
+      <description>Delay</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x3B" define="SECURITY_POLICY" type="SecurityPolicy" isNullable="true">
+      <description>SecurityPolicy</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x3C" define="DIAG_CHANNEL_MASK" type="octet_string" length="4" isNullable="true">
+      <description>ChannelPage0Mask</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x3D" define="OPERATIONAL_DATASET_COMPONENTS" type="OperationalDatasetComponents" isNullable="true">
+      <description>OperationalDatasetComponents</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x3E" define="ACTIVE_THREAD_NETWORK_FAULTS" type="array" entryType="NetworkFaultEnum" length="4">
+      <description>ActiveNetworkFaultsList</description>
+      <mandatoryConform/>
+    </attribute>
     <command source="client" code="0x00" name="ResetCounts" optional="true" cli="chip thread_network_diagnostics resetcounts">
       <description>Reception of this command SHALL reset the OverrunCount attributes to 0</description>
       <access op="invoke" privilege="manage"/>
+      <mandatoryConform>
+        <feature name="ERRCNT"/>
+      </mandatoryConform>
     </command>
     <event side="server" code="0x00" name="ConnectionStatus" priority="info" optional="true">
       <description>Indicate that a Node’s connection status to a Thread network has changed</description>
+      <optionalConform/>
       <field id="0" name="ConnectionStatus" type="ConnectionStatusEnum"/>
     </event>
     <event side="server" code="0x01" name="NetworkFaultChange" priority="info" optional="true">
       <description>Indicate a change in the set of network faults currently detected by the Node</description>
       <field id="0" name="Current" type="NetworkFaultEnum" array="true"/>
       <field id="1" name="Previous" type="NetworkFaultEnum" array="true"/>
+      <optionalConform/>
     </event>    
   </cluster>
 

--- a/src/app/zap-templates/zcl/data-model/chip/thread-network-directory-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/thread-network-directory-cluster.xml
@@ -15,58 +15,67 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <configurator>
-    <domain name="CHIP"/>
+  <domain name="CHIP"/>
+  
+  <struct name="ThreadNetworkStruct" apiMaturity="provisional">
+    <cluster code="0x0453"/>
+    <item name="ExtendedPanID" type="octet_string" length="8"/>
+    <item name="NetworkName" type="char_string" length="16"/>
+    <item name="Channel" type="int16u"/>
+    <item name="ActiveTimestamp" type="int64u"/>
+  </struct>
 
-    <struct name="ThreadNetworkStruct" apiMaturity="provisional">
-        <cluster code="0x0453"/>
-        <item name="ExtendedPanID" type="octet_string" length="8"/>
-        <item name="NetworkName" type="char_string" length="16"/>
-        <item name="Channel" type="int16u"/>
-        <item name="ActiveTimestamp" type="int64u"/>
-    </struct>
+  <cluster apiMaturity="provisional">
+    <domain>Network Infrastructure</domain>
+    <name>Thread Network Directory</name>
+    <code>0x0453</code>
+    <define>THREAD_NETWORK_DIRECTORY_CLUSTER</define>
+    <description>Manages the names and credentials of Thread networks visible to the user.</description>
 
-    <cluster apiMaturity="provisional">
-        <domain>Network Infrastructure</domain>
-        <name>Thread Network Directory</name>
-        <code>0x0453</code>
-        <define>THREAD_NETWORK_DIRECTORY_CLUSTER</define>
-        <description>Manages the names and credentials of Thread networks visible to the user.</description>
+    <client tick="false" init="false">true</client>
+    <server tick="false" init="false">true</server>
 
-        <client tick="false" init="false">true</client>
-        <server tick="false" init="false">true</server>
+    <!-- cluster revision -->
+    <globalAttribute side="either" code="0xFFFD" value="1"/>
+    
+    <attribute side="server" code="0x0000" define="PREFERRED_EXTENDED_PAN_ID" type="octet_string" length="8" writable="true" isNullable="true" optional="false">
+      <description>PreferredExtendedPanID</description>
+      <access op="read" privilege="manage"/>
+      <access op="write" privilege="manage"/>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="THREAD_NETWORKS" type="array" entryType="ThreadNetworkStruct" writable="false" optional="false">
+      <description>ThreadNetworks</description>
+      <access op="read" privilege="operate"/>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="THREAD_NETWORK_TABLE_SIZE" type="int8u" writable="false" optional="false">
+      <description>ThreadNetworkTableSize</description>
+      <mandatoryConform/>
+    </attribute>
 
-        <!-- cluster revision -->
-        <globalAttribute side="either" code="0xFFFD" value="1"/>
-
-        <attribute side="server" code="0x0000" define="PREFERRED_EXTENDED_PAN_ID" type="octet_string" length="8" writable="true" isNullable="true" optional="false">
-            <description>PreferredExtendedPanID</description>
-            <access op="read" privilege="manage"/>
-            <access op="write" privilege="manage"/>
-        </attribute>
-        <attribute side="server" code="0x0001" define="THREAD_NETWORKS" type="array" entryType="ThreadNetworkStruct" writable="false" optional="false">
-            <description>ThreadNetworks</description>
-            <access op="read" privilege="operate"/>
-        </attribute>
-        <attribute side="server" code="0x0002" define="THREAD_NETWORK_TABLE_SIZE" type="int8u" writable="false" optional="false">ThreadNetworkTableSize</attribute>
-
-        <command source="client" code="0x00" name="AddNetwork" mustUseTimedInvoke="true" optional="false">
-            <description>Adds an entry to the ThreadNetworks list.</description>
-            <access op="invoke" privilege="manage"/>
-            <arg name="OperationalDataset" type="octet_string" length="254"/>
-        </command>
-        <command source="client" code="0x01" name="RemoveNetwork" mustUseTimedInvoke="true" optional="false">
-            <description>Removes an entry from the ThreadNetworks list.</description>
-            <access op="invoke" privilege="manage"/>
-            <arg name="ExtendedPanID" type="octet_string" length="8"/>
-        </command>
-        <command source="client" code="0x02" name="GetOperationalDataset" optional="false" response="OperationalDatasetResponse">
-            <description>Retrieves a Thread Operational Dataset from the ThreadNetworks list.</description>
-            <access op="invoke" privilege="operate"/>
-            <arg name="ExtendedPanID" type="octet_string" length="8"/>
-        </command>
-        <command source="server" code="0x03" name="OperationalDatasetResponse" optional="false">
-            <description>This is the response to a GetOperationalDataset request.</description>
-            <arg name="OperationalDataset" type="octet_string" length="254"/>
-        </command>
-    </cluster>
+    <command source="client" code="0x00" name="AddNetwork" mustUseTimedInvoke="true" optional="false">
+      <description>Adds an entry to the ThreadNetworks list.</description>
+      <access op="invoke" privilege="manage"/>
+      <arg name="OperationalDataset" type="octet_string" length="254"/>
+      <mandatoryConform/>
+    </command>
+    <command source="client" code="0x01" name="RemoveNetwork" mustUseTimedInvoke="true" optional="false">
+      <description>Removes an entry from the ThreadNetworks list.</description>
+      <access op="invoke" privilege="manage"/>
+      <arg name="ExtendedPanID" type="octet_string" length="8"/>
+      <mandatoryConform/>
+    </command>
+    <command source="client" code="0x02" name="GetOperationalDataset" optional="false" response="OperationalDatasetResponse">
+      <description>Retrieves a Thread Operational Dataset from the ThreadNetworks list.</description>
+      <access op="invoke" privilege="operate"/>
+      <arg name="ExtendedPanID" type="octet_string" length="8"/>
+      <mandatoryConform/>
+    </command>
+    <command source="server" code="0x03" name="OperationalDatasetResponse" optional="false">
+      <description>This is the response to a GetOperationalDataset request.</description>
+      <arg name="OperationalDataset" type="octet_string" length="254"/>
+      <mandatoryConform/>
+    </command>
+  </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/time-format-localization-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/time-format-localization-cluster.xml
@@ -58,14 +58,23 @@ limitations under the License.
       </features>
 
     <!-- Base data types -->
-    <attribute side="server" code="0x00" define="HOUR_FORMAT" type="HourFormatEnum" writable="true" optional="false">
-        <description>HourFormat</description>
-        <access op="write" role="manage" />
+    <attribute side="server" code="0x00" define="HOUR_FORMAT" type="HourFormatEnum" writable="true">
+      <description>HourFormat</description>
+      <access op="write" role="manage"/>
+      <mandatoryConform/>
     </attribute>
     <attribute side="server" code="0x01" define="ACTIVE_CALENDAR_TYPE" type="CalendarTypeEnum" writable="true" optional="true">
-        <description>ActiveCalendarType</description>
-        <access op="write" role="manage" />
+      <description>ActiveCalendarType</description>
+      <access op="write" role="manage"/>
+      <mandatoryConform>
+        <feature name="CALFMT"/>
+      </mandatoryConform>
     </attribute>
-    <attribute side="server" code="0x02" define="SUPPORTED_CALENDAR_TYPES" type="array" entryType="CalendarTypeEnum" writable="false" optional="true">SupportedCalendarTypes</attribute>  
+    <attribute side="server" code="0x02" define="SUPPORTED_CALENDAR_TYPES" type="array" entryType="CalendarTypeEnum" optional="true">
+      <description>SupportedCalendarTypes</description>
+      <mandatoryConform>
+        <feature name="CALFMT"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/time-synchronization-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/time-synchronization-cluster.xml
@@ -114,78 +114,166 @@ limitations under the License.
       </feature>
     </features>
 
-    <attribute side="server" code="0x0000" define="UTC_TIME" type="epoch_us" isNullable="true" optional="false">UTCTime</attribute>
-    <attribute side="server" code="0x0001" define="GRANULARITY" type="GranularityEnum" default="0x00" optional="false">Granularity</attribute>
-    <attribute side="server" code="0x0002" define="TIME_SOURCE" type="TimeSourceEnum" default="0x00" optional="true">TimeSource</attribute>
-    <attribute side="server" code="0x0003" define="TRUSTED_TIME_SOURCE" type="TrustedTimeSourceStruct" isNullable="true" optional="true">TrustedTimeSource</attribute>
-    <attribute side="server" code="0x0004" define="DEFAULT_NTP" type="char_string" length="128" isNullable="true" optional="true">DefaultNTP</attribute>
-    <attribute side="server" code="0x0005" define="TIME_ZONE" type="array" entryType="TimeZoneStruct" optional="true">TimeZone</attribute>
-    <attribute side="server" code="0x0006" define="DST_OFFSET" type="array" entryType="DSTOffsetStruct" optional="true">DSTOffset</attribute>
-    <attribute side="server" code="0x0007" define="LOCAL_TIME" type="epoch_us" default="0xFFFFFFFFFFFFFFFF" isNullable="true" optional="true">LocalTime</attribute>
-    <attribute side="server" code="0x0008" define="TIME_ZONE_DATABASE" type="TimeZoneDatabaseEnum" default="2" optional="true">TimeZoneDatabase</attribute>
-    <attribute side="server" code="0x0009" define="NTP_SERVER_AVAILABLE" type="boolean" default="false" optional="true">NTPServerAvailable</attribute>
-    <attribute side="server" code="0x000A" define="TIME_ZONE_LIST_MAX_SIZE" type="int8u" min="1" max="2" optional="true">TimeZoneListMaxSize</attribute>
-    <attribute side="server" code="0x000B" define="DST_OFFSET_LIST_MAX_SIZE" type="int8u" min="1" optional="true">DSTOffsetListMaxSize</attribute>
-    <attribute side="server" code="0x000C" define="SUPPORTS_DNS_RESOLVE" type="boolean" default="false" optional="true">SupportsDNSResolve</attribute>
-
+    <attribute side="server" code="0x0000" define="UTC_TIME" type="epoch_us" isNullable="true">
+      <description>UTCTime</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="GRANULARITY" type="GranularityEnum" default="0x00">
+      <description>Granularity</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="TIME_SOURCE" type="TimeSourceEnum" default="0x00" optional="true">
+      <description>TimeSource</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="TRUSTED_TIME_SOURCE" type="TrustedTimeSourceStruct" isNullable="true" optional="true">
+      <description>TrustedTimeSource</description>
+      <mandatoryConform>
+        <feature name="TSC"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="DEFAULT_NTP" type="char_string" length="128" isNullable="true" optional="true">
+      <description>DefaultNTP</description>
+      <mandatoryConform>
+        <feature name="NTPC"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="TIME_ZONE" type="array" entryType="TimeZoneStruct" optional="true">
+      <description>TimeZone</description>
+      <mandatoryConform>
+        <feature name="TZ"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="DST_OFFSET" type="array" entryType="DSTOffsetStruct" optional="true">
+      <description>DSTOffset</description>
+      <mandatoryConform>
+        <feature name="TZ"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="LOCAL_TIME" type="epoch_us" default="0xFFFFFFFFFFFFFFFF" isNullable="true" optional="true">
+      <description>LocalTime</description>
+      <mandatoryConform>
+        <feature name="TZ"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="TIME_ZONE_DATABASE" type="TimeZoneDatabaseEnum" default="2" optional="true">
+      <description>TimeZoneDatabase</description>
+      <mandatoryConform>
+        <feature name="TZ"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="NTP_SERVER_AVAILABLE" type="boolean" optional="true">
+      <description>NTPServerAvailable</description>
+      <mandatoryConform>
+        <feature name="NTPS"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x000A" define="TIME_ZONE_LIST_MAX_SIZE" type="int8u" min="1" max="2" optional="true">
+      <description>TimeZoneListMaxSize</description>
+      <mandatoryConform>
+        <feature name="TZ"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x000B" define="DST_OFFSET_LIST_MAX_SIZE" type="int8u" min="1" optional="true">
+      <description>DSTOffsetListMaxSize</description>
+      <mandatoryConform>
+        <feature name="TZ"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x000C" define="SUPPORTS_DNS_RESOLVE" type="boolean" optional="true">
+      <description>SupportsDNSResolve</description>
+      <mandatoryConform>
+        <feature name="NTPC"/>
+      </mandatoryConform>
+    </attribute>
+    
     <command source="client" code="0x00" name="SetUTCTime" optional="false">
       <description>This command MAY be issued by Administrator to set the time.</description>
       <arg name="UTCTime" type="epoch_us"/>
       <arg name="Granularity" type="GranularityEnum"/>
       <arg name="TimeSource" type="TimeSourceEnum" optional="true"/>
       <access op="invoke" privilege="administer"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x01" name="SetTrustedTimeSource" isFabricScoped="true" optional="true">
       <description>This command SHALL set TrustedTimeSource.</description>
       <arg name="TrustedTimeSource" type="FabricScopedTrustedTimeSourceStruct" isNullable="true"/>
       <access op="invoke" privilege="administer"/>
+      <mandatoryConform>
+        <feature name="TSC"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x02" name="SetTimeZone" response="SetTimeZoneResponse" optional="true">
       <description>This command SHALL set TimeZone.</description>
       <arg name="TimeZone" type="TimeZoneStruct" array="true"/>
       <access op="invoke" privilege="manage"/>
+      <mandatoryConform>
+        <feature name="TZ"/>
+      </mandatoryConform>
     </command>
 
     <command source="server" code="0x03" name="SetTimeZoneResponse" optional="true">
       <description>Response to SetTimeZone.</description>
       <arg name="DSTOffsetRequired" type="boolean"/>
+      <mandatoryConform>
+        <feature name="TZ"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x04" name="SetDSTOffset" optional="true">
       <description>This command SHALL set DSTOffset.</description>
       <arg name="DSTOffset" type="DSTOffsetStruct" array="true"/>
       <access op="invoke" privilege="manage"/>
+      <mandatoryConform>
+        <feature name="TZ"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x05" name="SetDefaultNTP" optional="true">
       <description>This command is used to set DefaultNTP.</description>
       <arg name="DefaultNTP" type="char_string" length="128" isNullable="true"/>
       <access op="invoke" privilege="administer"/>
+      <mandatoryConform>
+        <feature name="NTPC"/>
+      </mandatoryConform>
     </command>
 
     <event code="0x0000" name="DSTTableEmpty" priority="info" side="server" optional="true">
       <description>This event SHALL be generated when the server stops applying the current DSTOffset and there are no entries in the list with a larger ValidStarting time.</description>
+      <mandatoryConform>
+        <feature name="TZ"/>
+      </mandatoryConform>
     </event>
 
     <event code="0x0001" name="DSTStatus" priority="info" side="server" optional="true">
       <description>This event SHALL be generated when the server starts or stops applying a DST offset.</description>
-      <field id="0" name="DSTOffsetActive" type="boolean" />
+      <field id="0" name="DSTOffsetActive" type="boolean"/>
+      <mandatoryConform>
+        <feature name="TZ"/>
+      </mandatoryConform>
     </event>
 
     <event code="0x0002" name="TimeZoneStatus" priority="info" side="server" optional="true">
       <description>This event SHALL be generated when the server changes its time zone offset or name.</description>
       <field id="0" name="Offset" type="int32s"/>
       <field id="1" name="Name" type="char_string" length="64" optional="true"/>
+      <mandatoryConform>
+        <feature name="TZ"/>
+      </mandatoryConform>
     </event>
 
     <event code="0x0003" name="TimeFailure" priority="info" side="server" optional="false">
       <description>This event SHALL be generated if the node has attempted to update its time, but was unable to find a good time from any source.</description>
+      <mandatoryConform/>
     </event>
 
     <event code="0x0004" name="MissingTrustedTimeSource" priority="info" side="server" optional="true">
       <description>This event SHALL be generated if the node attempts to update its time and finds that the TrustedTimeSource is null, or the specified peer cannot be reached.</description>
+      <mandatoryConform>
+        <feature name="TSC"/>
+      </mandatoryConform>
     </event>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/unit-localization-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/unit-localization-cluster.xml
@@ -43,8 +43,11 @@ limitations under the License.
     
     <!-- Base data types -->
     <attribute side="server" code="0x00" define="TEMPERATURE_UNIT" type="TempUnitEnum" min="0" max="2" writable="true" optional="true">
-        <description>TemperatureUnit</description>
-        <access op="write" role="manage"/>
+      <description>TemperatureUnit</description>
+      <access op="write" role="manage"/>
+      <mandatoryConform>
+        <feature name="TEMP"/>
+      </mandatoryConform>
     </attribute>
   </cluster>
 

--- a/src/app/zap-templates/zcl/data-model/chip/user-label-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/user-label-cluster.xml
@@ -27,6 +27,7 @@ limitations under the License.
       <description>LabelList</description>
       <access op="read" privilege="view"/>
       <access op="write" privilege="manage"/>
+      <mandatoryConform/>
     </attribute>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/valve-configuration-and-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/valve-configuration-and-control-cluster.xml
@@ -59,39 +59,86 @@ limitations under the License.
 
     <!-- min max definition for attribute size larger than 2 bytes is not allowed by zap codegen https://github.com/project-chip/zap/issues/1187 -->
     <!-- Therefore, this check needs to be done in code. -->
-    <attribute side="server" code="0x0000" define="OPEN_DURATION" type="elapsed_s" isNullable="true" writable="false" optional="false">OpenDuration</attribute>
+    <attribute side="server" code="0x0000" define="OPEN_DURATION" type="elapsed_s" isNullable="true">
+      <description>OpenDuration</description>
+      <mandatoryConform/>
+    </attribute>
     <!-- min max definition for attribute size larger than 2 bytes is not allowed by zap codegen https://github.com/project-chip/zap/issues/1187 -->
     <!-- Therefore, this check needs to be done in code. -->
-    <attribute side="server" code="0x0001" define="DEFAULT_OPEN_DURATION" type="elapsed_s" isNullable="true" writable="true" optional="false">DefaultOpenDuration</attribute>
-    <attribute side="server" code="0x0002" define="AUTO_CLOSE_TIME" type="epoch_us" isNullable="true" writable="false" optional="true">AutoCloseTime</attribute>
-    <attribute side="server" code="0x0003" define="REMAINING_DURATION" type="elapsed_s" isNullable="true" writable="false" optional="false">RemainingDuration</attribute>
-    <attribute side="server" code="0x0004" define="CURRENT_STATE" type="ValveStateEnum" isNullable="true" writable="false" optional="false">CurrentState</attribute>
-    <attribute side="server" code="0x0005" define="TARGET_STATE" type="ValveStateEnum" isNullable="true" writable="false" optional="false">TargetState</attribute>
-    <attribute side="server" code="0x0006" define="CURRENT_LEVEL" type="percent" isNullable="true" min="0" max="100" writable="false" optional="true">CurrentLevel</attribute>
-    <attribute side="server" code="0x0007" define="TARGET_LEVEL" type="percent" isNullable="true" min="0" max="100" writable="false" optional="true">TargetLevel</attribute>
-    <attribute side="server" code="0x0008" define="DEFAULT_OPEN_LEVEL" type="percent" isNullable="false" min="1" max="100" writable="true" default="100" optional="true">DefaultOpenLevel</attribute>
-    <attribute side="server" code="0x0009" define="VALVE_FAULT" type="ValveFaultBitmap" isNullable="false" writable="false" optional="true">ValveFault</attribute>
-    <attribute side="server" code="0x000A" define="LEVEL_STEP" type="int8u" min="1" max="50" isNullable="false" writable="false" optional="true">LevelStep</attribute>
-
+    <attribute side="server" code="0x0001" define="DEFAULT_OPEN_DURATION" type="elapsed_s" isNullable="true" writable="true">
+      <description>DefaultOpenDuration</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="AUTO_CLOSE_TIME" type="epoch_us" isNullable="true" optional="true">
+      <description>AutoCloseTime</description>
+      <mandatoryConform>
+        <feature name="TS"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="REMAINING_DURATION" type="elapsed_s" isNullable="true">
+      <description>RemainingDuration</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0004" define="CURRENT_STATE" type="ValveStateEnum" isNullable="true">
+      <description>CurrentState</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0005" define="TARGET_STATE" type="ValveStateEnum" isNullable="true">
+      <description>TargetState</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0006" define="CURRENT_LEVEL" type="percent" isNullable="true" optional="true">
+      <description>CurrentLevel</description>
+      <mandatoryConform>
+        <feature name="LVL"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="TARGET_LEVEL" type="percent" isNullable="true" optional="true">
+      <description>TargetLevel</description>
+      <mandatoryConform>
+        <feature name="LVL"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="DEFAULT_OPEN_LEVEL" type="percent" min="1" max="100" writable="true" default="100" optional="true">
+      <description>DefaultOpenLevel</description>
+      <optionalConform>
+        <feature name="LVL"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="VALVE_FAULT" type="ValveFaultBitmap" optional="true">
+      <description>ValveFault</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x000A" define="LEVEL_STEP" type="int8u" min="1" max="50" optional="true">
+      <description>LevelStep</description>
+      <optionalConform>
+        <feature name="LVL"/>
+      </optionalConform>
+    </attribute>
+    
     <command source="client" code="0x00" name="Open" optional="false">
       <description>This command is used to set the valve to its open position.</description>
       <arg name="OpenDuration" type="elapsed_s" optional="true" isNullable="true"/>
       <arg name="TargetLevel" type="percent" optional="true"/>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x01" name="Close" optional="false">
       <description>This command is used to set the valve to its closed position.</description>
+      <mandatoryConform/>
     </command>
 
     <event side="server" code="0x00" priority="info" name="ValveStateChanged" optional="true">
       <description>This event SHALL be generated when the valve state changed.</description>
       <field id="0" name="ValveState" type="ValveStateEnum"/>
       <field id="1" name="ValveLevel" type="percent" optional="true"/>
+      <optionalConform/>
     </event>
 
     <event side="server" code="0x01" priority="info" name="ValveFault" optional="true">
       <description>This event SHALL be generated when the valve registers or clears a fault.</description>
       <field id="0" name="ValveFault" type="ValveFaultBitmap"/>
+      <optionalConform/>
     </event>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/wake-on-lan-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/wake-on-lan-cluster.xml
@@ -27,8 +27,14 @@ limitations under the License.
 
     <!-- Current cluster version -->
     <globalAttribute side="either" code="0xFFFD" value="1"/>
-
-    <attribute side="server" code="0x0000" define="WAKE_ON_LAN_MAC_ADDRESS" type="char_string" length="12" writable="false" optional="true">MACAddress</attribute>
-    <attribute apiMaturity="provisional" side="server" code="0x0001" define="LINK_LOCAL_ADDRESS" type="octet_string" length="16" writable="false" optional="true">LinkLocalAddress</attribute>
+    
+    <attribute side="server" code="0x0000" define="WAKE_ON_LAN_MAC_ADDRESS" type="char_string" length="12" optional="true">
+      <description>MACAddress</description>
+      <optionalConform/>
+    </attribute>
+    <attribute apiMaturity="provisional" side="server" code="0x0001" define="LINK_LOCAL_ADDRESS" type="octet_string" length="16" optional="true">
+      <description>LinkLocalAddress</description>
+      <optionalConform/>
+    </attribute>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/washer-controls-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/washer-controls-cluster.xml
@@ -45,11 +45,31 @@ limitations under the License.
         <optionalConform/>
       </feature>
     </features>
-
-    <attribute side="server" code="0x0000" define="SPIN_SPEEDS"               type="array" entryType="char_string"                                writable="false" isNullable="false" optional="true">SpinSpeeds</attribute>
-    <attribute side="server" code="0x0001" define="SPIN_SPEED_CURRENT"        type="int8u"                                min="0x00" max="0x1F"   writable="true"  isNullable="true"  optional="true">SpinSpeedCurrent</attribute>
-    <attribute side="server" code="0x0002" define="NUMBER_OF_RINSES"          type="NumberOfRinsesEnum"                                           writable="true"  isNullable="false"  optional="true">NumberOfRinses</attribute>
-    <attribute side="server" code="0x0003" define="SUPPORTED_RINSES"          type="array" entryType="NumberOfRinsesEnum"                      writable="false"  isNullable="false"  optional="true">SupportedRinses</attribute>
+    
+    <attribute side="server" code="0x0000" define="SPIN_SPEEDS" type="array" entryType="char_string" optional="true">
+      <description>SpinSpeeds</description>
+      <mandatoryConform>
+        <feature name="SPIN"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="SPIN_SPEED_CURRENT" type="int8u" max="0x1F" writable="true" isNullable="true" optional="true">
+      <description>SpinSpeedCurrent</description>
+      <mandatoryConform>
+        <feature name="SPIN"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="NUMBER_OF_RINSES" type="NumberOfRinsesEnum" writable="true" optional="true">
+      <description>NumberOfRinses</description>
+      <mandatoryConform>
+        <feature name="RINSE"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="SUPPORTED_RINSES" type="array" entryType="NumberOfRinsesEnum" optional="true">
+      <description>SupportedRinses</description>
+      <mandatoryConform>
+        <feature name="RINSE"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 </configurator>
  

--- a/src/app/zap-templates/zcl/data-model/chip/water-heater-management-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/water-heater-management-cluster.xml
@@ -64,30 +64,58 @@ Git: 1.4-prerelease-ipr-69-ge15ff5700
     </features>
     <server init="false" tick="false">true</server>
     <globalAttribute code="0xFFFD" side="either" value="2"/>
-    <attribute code="0x0000" side="server" define="HEATER_TYPES" type="WaterHeaterHeatSourceBitmap" min="0x00" max="0x1F" default="0x00">HeaterTypes</attribute>
-    <attribute code="0x0001" side="server" define="HEAT_DEMAND" type="WaterHeaterHeatSourceBitmap" min="0x00" max="0x1F" default="0x00">HeatDemand</attribute>
-    <attribute code="0x0002" side="server" define="TANK_VOLUME" type="int16u" default="0" optional="true">TankVolume</attribute>
-    <attribute code="0x0003" side="server" define="ESTIMATED_HEAT_REQUIRED" type="energy_mwh" default="0" optional="true" min="0">EstimatedHeatRequired</attribute>
-    <attribute code="0x0004" side="server" define="TANK_PERCENTAGE" type="percent" default="0" optional="true">TankPercentage</attribute>
-    <attribute code="0x0005" side="server" define="BOOST_STATE" type="BoostStateEnum" default="0" min="0x00" max="0x01">BoostState</attribute>
+    <attribute code="0x0000" side="server" define="HEATER_TYPES" type="WaterHeaterHeatSourceBitmap" min="0x00" max="0x1F" default="0x00">
+      <description>HeaterTypes</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute code="0x0001" side="server" define="HEAT_DEMAND" type="WaterHeaterHeatSourceBitmap" min="0x00" max="0x1F" default="0x00">
+      <description>HeatDemand</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute code="0x0002" side="server" define="TANK_VOLUME" type="int16u" default="0" optional="true">
+      <description>TankVolume</description>
+      <mandatoryConform>
+        <feature name="EM"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute code="0x0003" side="server" define="ESTIMATED_HEAT_REQUIRED" type="energy_mwh" default="0" optional="true" min="0">
+      <description>EstimatedHeatRequired</description>
+      <mandatoryConform>
+        <feature name="EM"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute code="0x0004" side="server" define="TANK_PERCENTAGE" type="percent" default="0" optional="true">
+      <description>TankPercentage</description>
+      <mandatoryConform>
+        <feature name="TP"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute code="0x0005" side="server" define="BOOST_STATE" type="BoostStateEnum" default="0" min="0x00" max="0x01">
+      <description>BoostState</description>
+      <mandatoryConform/>
+    </attribute>
     <command code="0x00" source="client" name="Boost" optional="false" apiMaturity="provisional">
       <description>Allows a client to request that the water heater is put into a Boost state.</description>
       <arg id="0" name="BoostInfo" type="WaterHeaterBoostInfoStruct"/>
       <access op="invoke" privilege="manage"/>
+      <mandatoryConform/>
     </command>
 
     <command code="0x01" source="client" name="CancelBoost" optional="false" apiMaturity="provisional">
       <description>Allows a client to cancel an ongoing Boost operation.</description>
       <access op="invoke" privilege="manage"/>
+      <mandatoryConform/>
     </command>
 
     <event code="0x0000" name="BoostStarted" priority="info" side="server">
       <description>This event SHALL be generated whenever a Boost command is accepted.</description>
       <field id="0" name="BoostInfo" type="WaterHeaterBoostInfoStruct"/>
+      <mandatoryConform/>
     </event>
 
     <event code="0x0001" name="BoostEnded" priority="info" side="server">
       <description>This event SHALL be generated whenever the BoostState transitions from Active to Inactive.</description>
+      <mandatoryConform/>
     </event>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/water-heater-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/water-heater-mode-cluster.xml
@@ -58,18 +58,26 @@ Git: 1.4-prerelease-ipr-69-ge15ff5700
       </feature>
     </features>
     <!-- Base data types -->
-    <attribute side="server" code="0x0000" define="SUPPORTED_MODES" type="array" entryType="ModeOptionStruct" length="255" minLength="2">SupportedModes</attribute>
-    <attribute side="server" code="0x0001" define="CURRENT_MODE" type="int8u">CurrentMode</attribute>
+    <attribute side="server" code="0x0000" define="SUPPORTED_MODES" type="array" entryType="ModeOptionStruct" length="255" minLength="2">
+      <description>SupportedModes</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="CURRENT_MODE" type="int8u">
+      <description>CurrentMode</description>
+      <mandatoryConform/>
+    </attribute>
     <!-- Commands -->
     <command source="client" code="0x00" name="ChangeToMode" response="ChangeToModeResponse" optional="false">
       <description>This command is used to change device modes.</description>
       <arg id="0" name="NewMode" type="int8u"/>
+      <mandatoryConform/>
     </command>
 
     <command source="server" code="0x01" name="ChangeToModeResponse" disableDefaultResponse="true" optional="false">
       <description>This command is sent by the device on receipt of the ChangeToMode command.</description>
       <arg id="0" name="Status" type="enum8"/>
       <arg id="1" name="StatusText" type="char_string" lenght="64" optional="true" length="64"/>
+      <mandatoryConform/>
     </command>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/wifi-network-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/wifi-network-diagnostics-cluster.xml
@@ -63,35 +63,94 @@ limitations under the License.
         <optionalConform/>
       </feature>
     </features>
-  
-    <attribute side="server" code="0x00" define="BSSID" type="octet_string" length="6" writable="false" isNullable="true" optional="false">BSSID</attribute>
-    <attribute side="server" code="0x01" define="SECURITY_TYPE" type="SecurityTypeEnum" writable="false" isNullable="true" optional="false">SecurityType</attribute>
-    <attribute side="server" code="0x02" define="WIFI_VERSION" type="WiFiVersionEnum" writable="false" isNullable="true" optional="false">WiFiVersion</attribute>
-    <attribute side="server" code="0x03" define="CHANNEL_NUMBER" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x0000" isNullable="true" optional="false">ChannelNumber</attribute>
-    <attribute side="server" code="0x04" define="RSSI" type="int8s" min="-120" max="0" writable="false" isNullable="true" optional="false">RSSI</attribute>
-    <attribute side="server" code="0x05" define="BEACON_LOST_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" isNullable="true" optional="true">BeaconLostCount</attribute>
-    <attribute side="server" code="0x06" define="BEACON_RX_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" isNullable="true" optional="true">BeaconRxCount</attribute>
-    <attribute side="server" code="0x07" define="PACKET_MULTICAST_RX_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" isNullable="true" optional="true">PacketMulticastRxCount</attribute>
-    <attribute side="server" code="0x08" define="PACKET_MULTICAST_TX_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" isNullable="true" optional="true">PacketMulticastTxCount</attribute>
-    <attribute side="server" code="0x09" define="PACKET_UNICAST_RX_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" isNullable="true" optional="true">PacketUnicastRxCount</attribute>
-    <attribute side="server" code="0x0A" define="PACKET_UNICAST_TX_COUNT" type="int32u" min="0x00000000" max="0xFFFFFFFF" writable="false" default="0x00000000" isNullable="true" optional="true">PacketUnicastTxCount</attribute>
-    <attribute side="server" code="0x0B" define="CURRENT_MAX_RATE" type="int64u" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" isNullable="true" optional="true">CurrentMaxRate</attribute>
-    <attribute side="server" code="0x0C" define="OVERRUN_COUNT" type="int64u" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" isNullable="true" optional="true">OverrunCount</attribute>
+    
+    <attribute side="server" code="0x00" define="BSSID" type="octet_string" length="6" isNullable="true" minLength="6">
+      <description>BSSID</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x01" define="SECURITY_TYPE" type="SecurityTypeEnum" isNullable="true">
+      <description>SecurityType</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x02" define="WIFI_VERSION" type="WiFiVersionEnum" isNullable="true">
+      <description>WiFiVersion</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x03" define="CHANNEL_NUMBER" type="int16u" isNullable="true">
+      <description>ChannelNumber</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x04" define="RSSI" type="int8s" min="-120" max="0" isNullable="true">
+      <description>RSSI</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x05" define="BEACON_LOST_COUNT" type="int32u" default="0x00000000" isNullable="true" optional="true">
+      <description>BeaconLostCount</description>
+      <mandatoryConform>
+        <feature name="ERRCNT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x06" define="BEACON_RX_COUNT" type="int32u" default="0x00000000" isNullable="true" optional="true">
+      <description>BeaconRxCount</description>
+      <mandatoryConform>
+        <feature name="PKTCNT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x07" define="PACKET_MULTICAST_RX_COUNT" type="int32u" default="0x00000000" isNullable="true" optional="true">
+      <description>PacketMulticastRxCount</description>
+      <mandatoryConform>
+        <feature name="PKTCNT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x08" define="PACKET_MULTICAST_TX_COUNT" type="int32u" default="0x00000000" isNullable="true" optional="true">
+      <description>PacketMulticastTxCount</description>
+      <mandatoryConform>
+        <feature name="PKTCNT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x09" define="PACKET_UNICAST_RX_COUNT" type="int32u" default="0x00000000" isNullable="true" optional="true">
+      <description>PacketUnicastRxCount</description>
+      <mandatoryConform>
+        <feature name="PKTCNT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0A" define="PACKET_UNICAST_TX_COUNT" type="int32u" default="0x00000000" isNullable="true" optional="true">
+      <description>PacketUnicastTxCount</description>
+      <mandatoryConform>
+        <feature name="PKTCNT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0B" define="CURRENT_MAX_RATE" type="int64u" default="0x0000000000000000" isNullable="true" optional="true">
+      <description>CurrentMaxRate</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0C" define="OVERRUN_COUNT" type="int64u" default="0x0000000000000000" isNullable="true" optional="true">
+      <description>OverrunCount</description>
+      <mandatoryConform>
+        <feature name="ERRCNT"/>
+      </mandatoryConform>
+    </attribute>
     <command source="client" code="0x00" name="ResetCounts" optional="true" cli="chip wifi_network_diagnostics resetcounts">
       <description>Reception of this command SHALL reset the Breacon and Packet related count attributes to 0</description>
+      <mandatoryConform>
+        <feature name="ERRCNT"/>
+      </mandatoryConform>
     </command>
     <event side="server" code="0x00" name="Disconnection" priority="info" optional="true">
       <description>Indicate that a Node’s Wi-Fi connection has been disconnected as a result of de-authenticated or dis-association and indicates the reason.</description>
       <field id="0" name="ReasonCode" type="int16u"/>
+      <optionalConform/>
     </event>
     <event side="server" code="0x01" name="AssociationFailure" priority="info" optional="true">
       <description>Indicate that a Node has failed to connect, or reconnect, to a Wi-Fi access point.</description>
       <field id="0" name="AssociationFailureCause" type="AssociationFailureCauseEnum"/>
       <field id="1" name="Status" type="int16u"/>
+      <optionalConform/>
     </event>
     <event side="server" code="0x02" name="ConnectionStatus" priority="info" optional="true">
       <description>Indicate that a Node’s connection status to a Wi-Fi network has changed.</description>
       <field id="0" name="ConnectionStatus" type="ConnectionStatusEnum"/>
+      <optionalConform/>
     </event>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/wifi-network-management-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/wifi-network-management-cluster.xml
@@ -30,19 +30,25 @@ limitations under the License.
         <!-- cluster revision -->
         <globalAttribute side="either" code="0xFFFD" value="1"/>
 
-        <attribute side="server" code="0x0000" define="SSID" type="octet_string" length="32" writable="false" isNullable="true" optional="false">SSID</attribute>
+        <attribute side="server" code="0x0000" define="SSID" type="octet_string" length="32" writable="false" isNullable="true" optional="false">
+            <description>SSID</description>
+            <mandatoryConform/>
+        </attribute>
         <attribute side="server" code="0x0001" define="PASSPHRASE_SURROGATE" type="int64u" writable="false" isNullable="true" optional="false">
             <description>PassphraseSurrogate</description>
             <access op="read" privilege="manage"/>
+            <mandatoryConform/>
         </attribute>
 
         <command source="client" code="0x00" name="NetworkPassphraseRequest" optional="false" response="NetworkPassphraseResponse">
             <description>Request the current WPA-Personal passphrase or PSK associated with the managed Wi-Fi network.</description>
             <access op="invoke" privilege="manage"/>
+            <mandatoryConform/>
         </command>
         <command source="server" code="0x01" name="NetworkPassphraseResponse" optional="false">
             <description>This is the response to a NetworkPassphraseRequest.</description>
             <arg name="Passphrase" type="octet_string" length="64"/>
+            <mandatoryConform/>
         </command>
     </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/window-covering.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/window-covering.xml
@@ -57,45 +57,186 @@ limitations under the License.
 
     <!-- Window Covering Information Attribute Set -->
     <!-- Conformance feature M -->
-    <attribute side="server" writable="false" code="0x0000" define="WC_TYPE"                                      type="Type"     min="0x00"   max="0x09"   default="0x00"   optional="false">Type</attribute>
+    <attribute side="server" code="0x0000" define="WC_TYPE" type="Type" min="0x00" max="0x09" default="0x00">
+      <description>Type</description>
+      <mandatoryConform/>
+    </attribute>
     <!-- Conformance feature [LF & PA_LF & ABS] - for now optional -->
-    <attribute side="server" writable="false" code="0x0001" define="WC_PHYSICAL_CLOSED_LIMIT_LIFT"                type="int16u"   min="0x0000" max="0xFFFF" default="0x0000" optional="true" >PhysicalClosedLimitLift</attribute>
+    <attribute side="server" code="0x0001" define="WC_PHYSICAL_CLOSED_LIMIT_LIFT" type="int16u" default="0x0000" optional="true">
+      <description>PhysicalClosedLimitLift</description>
+      <optionalConform>
+        <andTerm>
+          <feature name="LF"/>
+          <feature name="PA_LF"/>
+          <feature name="ABS"/>
+        </andTerm>
+      </optionalConform>
+    </attribute>
     <!-- Conformance feature [TL & PA_TL & ABS] - for now optional -->
-    <attribute side="server" writable="false" code="0x0002" define="WC_PHYSICAL_CLOSED_LIMIT_TILT"                type="int16u"   min="0x0000" max="0xFFFF" default="0x0000" optional="true" >PhysicalClosedLimitTilt</attribute>
+    <attribute side="server" code="0x0002" define="WC_PHYSICAL_CLOSED_LIMIT_TILT" type="int16u" default="0x0000" optional="true">
+      <description>PhysicalClosedLimitTilt</description>
+      <optionalConform>
+        <andTerm>
+          <feature name="TL"/>
+          <feature name="PA_TL"/>
+          <feature name="ABS"/>
+        </andTerm>
+      </optionalConform>
+    </attribute>
     <!-- Conformance feature [LF & PA_LF & ABS] - for now optional -->
-    <attribute side="server" writable="false" code="0x0003" define="WC_CURRENT_POSITION_LIFT"                     type="int16u"   min="0x0000" max="0xFFFF" isNullable="true" optional="true">CurrentPositionLift</attribute>
+    <attribute side="server" code="0x0003" define="WC_CURRENT_POSITION_LIFT" type="int16u" max="65534" isNullable="true" optional="true">
+      <description>CurrentPositionLift</description>
+      <optionalConform>
+        <andTerm>
+          <feature name="LF"/>
+          <feature name="PA_LF"/>
+          <feature name="ABS"/>
+        </andTerm>
+      </optionalConform>
+    </attribute>
     <!-- Conformance feature [TL & PA_TL & ABS] - for now optional -->
-    <attribute side="server" writable="false" code="0x0004" define="WC_CURRENT_POSITION_TILT"                     type="int16u"   min="0x0000" max="0xFFFF" isNullable="true" optional="true">CurrentPositionTilt</attribute>
+    <attribute side="server" code="0x0004" define="WC_CURRENT_POSITION_TILT" type="int16u" max="65534" isNullable="true" optional="true">
+      <description>CurrentPositionTilt</description>
+      <optionalConform>
+        <andTerm>
+          <feature name="TL"/>
+          <feature name="PA_TL"/>
+          <feature name="ABS"/>
+        </andTerm>
+      </optionalConform>
+    </attribute>
     <!-- Conformance feature [LF] - for now optional -->
-    <attribute side="server" writable="false" code="0x0005" define="WC_NUMBER_OF_ACTUATIONS_LIFT"                 type="int16u"   min="0x0000" max="0xFFFF" default="0x0000" optional="true" >NumberOfActuationsLift</attribute>
+    <attribute side="server" code="0x0005" define="WC_NUMBER_OF_ACTUATIONS_LIFT" type="int16u" default="0x0000" optional="true">
+      <description>NumberOfActuationsLift</description>
+      <optionalConform>
+        <feature name="LF"/>
+      </optionalConform>
+    </attribute>
     <!-- Conformance feature [TL] - for now optional -->
-    <attribute side="server" writable="false" code="0x0006" define="WC_NUMBER_OF_ACTUATIONS_TILT"                 type="int16u"   min="0x0000" max="0xFFFF" default="0x0000" optional="true" >NumberOfActuationsTilt</attribute>
+    <attribute side="server" code="0x0006" define="WC_NUMBER_OF_ACTUATIONS_TILT" type="int16u" default="0x0000" optional="true">
+      <description>NumberOfActuationsTilt</description>
+      <optionalConform>
+        <feature name="TL"/>
+      </optionalConform>
+    </attribute>
     <!-- Conformance feature M -->
-    <attribute side="server" writable="false" code="0x0007" define="WC_CONFIG_STATUS"                             type="ConfigStatus" min="0x00"   max="0x7F"   default="0x03"   optional="false">ConfigStatus</attribute>
+    <attribute side="server" code="0x0007" define="WC_CONFIG_STATUS" type="ConfigStatus" min="0x00" max="0x7F" default="0x03">
+      <description>ConfigStatus</description>
+      <mandatoryConform/>
+    </attribute>
     <!-- Conformance feature [LF & PA_LF] - for now optional -->
-    <attribute side="server" writable="false" code="0x0008" define="WC_CURRENT_POSITION_LIFT_PERCENTAGE"          type="percent"  min="0"      max="100"    isNullable="true" optional="true" reportable="true" >CurrentPositionLiftPercentage</attribute>
+    <attribute side="server" code="0x0008" define="WC_CURRENT_POSITION_LIFT_PERCENTAGE" type="percent" isNullable="true" optional="true" reportable="true">
+      <description>CurrentPositionLiftPercentage</description>
+      <optionalConform>
+        <andTerm>
+          <feature name="LF"/>
+          <feature name="PA_LF"/>
+        </andTerm>
+      </optionalConform>
+    </attribute>
     <!-- Conformance feature [TL & PA_TL] - for now optional -->
-    <attribute side="server" writable="false" code="0x0009" define="WC_CURRENT_POSITION_TILT_PERCENTAGE"          type="percent"  min="0"      max="100"    isNullable="true" optional="true" reportable="true" >CurrentPositionTiltPercentage</attribute>
+    <attribute side="server" code="0x0009" define="WC_CURRENT_POSITION_TILT_PERCENTAGE" type="percent" isNullable="true" optional="true" reportable="true">
+      <description>CurrentPositionTiltPercentage</description>
+      <optionalConform>
+        <andTerm>
+          <feature name="TL"/>
+          <feature name="PA_TL"/>
+        </andTerm>
+      </optionalConform>
+    </attribute>
     <!-- Conformance feature M -->
-    <attribute side="server" writable="false" code="0x000A" define="WC_OPERATIONAL_STATUS"                        type="OperationalStatus" min="0x00"   max="0x7F"   default="0x00"   optional="false" reportable="true" >OperationalStatus</attribute>
+    <attribute side="server" code="0x000A" define="WC_OPERATIONAL_STATUS" type="OperationalStatus" min="0x00" max="0x7F" default="0x00" reportable="true">
+      <description>OperationalStatus</description>
+      <mandatoryConform/>
+    </attribute>
     <!-- Conformance feature LF & PA_LF - for now optional -->
-    <attribute side="server" writable="false" code="0x000B" define="WC_TARGET_POSITION_LIFT_PERCENT100THS"        type="percent100ths" min="0" max="10000"  isNullable="true" optional="true" reportable="true" >TargetPositionLiftPercent100ths</attribute>
+    <attribute side="server" code="0x000B" define="WC_TARGET_POSITION_LIFT_PERCENT100THS" type="percent100ths" isNullable="true" optional="true" reportable="true">
+      <description>TargetPositionLiftPercent100ths</description>
+      <mandatoryConform>
+        <andTerm>
+          <feature name="LF"/>
+          <feature name="PA_LF"/>
+        </andTerm>
+      </mandatoryConform>
+    </attribute>
     <!-- Conformance feature TL & PA_TL - for now optional -->
-    <attribute side="server" writable="false" code="0x000C" define="WC_TARGET_POSITION_TILT_PERCENT100THS"        type="percent100ths" min="0" max="10000"  isNullable="true" optional="true" reportable="true" >TargetPositionTiltPercent100ths</attribute>
+    <attribute side="server" code="0x000C" define="WC_TARGET_POSITION_TILT_PERCENT100THS" type="percent100ths" isNullable="true" optional="true" reportable="true">
+      <description>TargetPositionTiltPercent100ths</description>
+      <mandatoryConform>
+        <andTerm>
+          <feature name="TL"/>
+          <feature name="PA_TL"/>
+        </andTerm>
+      </mandatoryConform>
+    </attribute>
     <!-- Conformance feature M -->
-    <attribute side="server" writable="false" code="0x000D" define="WC_END_PRODUCT_TYPE"                          type="EndProductType" min="0x00"   max="0x20"   default="0x00"   optional="false" >EndProductType</attribute>
+    <attribute side="server" code="0x000D" define="WC_END_PRODUCT_TYPE" type="EndProductType" min="0x00" max="0x20" default="0x00">
+      <description>EndProductType</description>
+      <mandatoryConform/>
+    </attribute>
     <!-- Conformance feature LF & PA_LF - for now optional -->
-    <attribute side="server" writable="false" code="0x000E" define="WC_CURRENT_POSITION_LIFT_PERCENT100THS"       type="percent100ths" min="0" max="10000"  isNullable="true" optional="true" reportable="true" >CurrentPositionLiftPercent100ths</attribute>
+    <attribute side="server" code="0x000E" define="WC_CURRENT_POSITION_LIFT_PERCENT100THS" type="percent100ths" max="10000" isNullable="true" optional="true" reportable="true">
+      <description>CurrentPositionLiftPercent100ths</description>
+      <mandatoryConform>
+        <andTerm>
+          <feature name="LF"/>
+          <feature name="PA_LF"/>
+        </andTerm>
+      </mandatoryConform>
+    </attribute>
     <!-- Conformance feature TL & PA_TL - for now optional -->
-    <attribute side="server" writable="false" code="0x000F" define="WC_CURRENT_POSITION_TILT_PERCENT100THS"       type="percent100ths" min="0" max="10000"  isNullable="true" optional="true" reportable="true" >CurrentPositionTiltPercent100ths</attribute>
-
+    <attribute side="server" code="0x000F" define="WC_CURRENT_POSITION_TILT_PERCENT100THS" type="percent100ths" max="10000" isNullable="true" optional="true" reportable="true">
+      <description>CurrentPositionTiltPercent100ths</description>
+      <mandatoryConform>
+        <andTerm>
+          <feature name="TL"/>
+          <feature name="PA_TL"/>
+        </andTerm>
+      </mandatoryConform>
+    </attribute>
     <!-- Window Covering Settings Attribute Set -->
     <!-- Conformance feature LF & PA_LF & ABS - for now optional -->
-    <attribute side="server" writable="false" code="0x0010" define="WC_INSTALLED_OPEN_LIMIT_LIFT"                 type="int16u"   min="0x0000" max="0xFFFF" default="0x0000" optional="true" >InstalledOpenLimitLift</attribute>
-    <attribute side="server" writable="false" code="0x0011" define="WC_INSTALLED_CLOSED_LIMIT_LIFT"               type="int16u"   min="0x0000" max="0xFFFF" default="0xFFFF" optional="true" >InstalledClosedLimitLift</attribute>
+    <attribute side="server" code="0x0010" define="WC_INSTALLED_OPEN_LIMIT_LIFT" type="int16u" max="65534" default="0x0000" optional="true">
+      <description>InstalledOpenLimitLift</description>
+      <mandatoryConform>
+        <andTerm>
+          <feature name="LF"/>
+          <feature name="PA_LF"/>
+          <feature name="ABS"/>
+        </andTerm>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0011" define="WC_INSTALLED_CLOSED_LIMIT_LIFT" type="int16u" max="65534" default="65534" optional="true">
+      <description>InstalledClosedLimitLift</description>
+      <mandatoryConform>
+        <andTerm>
+          <feature name="LF"/>
+          <feature name="PA_LF"/>
+          <feature name="ABS"/>
+        </andTerm>
+      </mandatoryConform>
+    </attribute>
     <!-- Conformance feature TL & PA_TL & ABS - for now optional -->
-    <attribute side="server" writable="false" code="0x0012" define="WC_INSTALLED_OPEN_LIMIT_TILT"                 type="int16u"   min="0x0000" max="0xFFFF" default="0x0000" optional="true" >InstalledOpenLimitTilt</attribute>
-    <attribute side="server" writable="false" code="0x0013" define="WC_INSTALLED_CLOSED_LIMIT_TILT"               type="int16u"   min="0x0000" max="0xFFFF" default="0xFFFF" optional="true" >InstalledClosedLimitTilt</attribute>
+    <attribute side="server" code="0x0012" define="WC_INSTALLED_OPEN_LIMIT_TILT" type="int16u" max="65534" default="0x0000" optional="true">
+      <description>InstalledOpenLimitTilt</description>
+      <mandatoryConform>
+        <andTerm>
+          <feature name="TL"/>
+          <feature name="PA_TL"/>
+          <feature name="ABS"/>
+        </andTerm>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0013" define="WC_INSTALLED_CLOSED_LIMIT_TILT" type="int16u" max="65534" default="65534" optional="true">
+      <description>InstalledClosedLimitTilt</description>
+      <mandatoryConform>
+        <andTerm>
+          <feature name="TL"/>
+          <feature name="PA_TL"/>
+          <feature name="ABS"/>
+        </andTerm>
+      </mandatoryConform>
+    </attribute>
     <!-- Conformance Deprecated -->
     <!-- attribute side="server" writable="true"  code="0x0014" define="WC_VELOCITY_LIFT"                         type="int16u"   min="0x0000" max="0xFFFF" default="0x0000" optional="true" >VelocityLift -->
     <!-- attribute side="server" writable="true"  code="0x0015" define="WC_ACCELERATION_TIME_LIFT"                type="int16u"   min="0x0000" max="0xFFFF" default="0x0000" optional="true" >AccelerationTimeLift -->
@@ -104,44 +245,85 @@ limitations under the License.
     <attribute side="server" writable="true"  code="0x0017" define="WC_MODE"                                      type="Mode"  min="0x00"   max="0x0F"   default="0x00"   optional="false" >
       <description>Mode</description>
       <access op="read" role="view" />
-      <access op="write" role="manage" />
+      <access op="write" role="manage"/>
+      <mandatoryConform/>
     </attribute>
     <!-- Conformance Deprecated -->
     <!-- attribute side="server" writable="true"  code="0x0018" define="WC_INTERMEDIATE_SETPOINTS_LIFT"           type="octet_string" length="254" default="1,0x0000"        optional="true" >IntermediateSetpointsLift</attribute> -->
     <!-- attribute side="server" writable="true"  code="0x0019" define="WC_INTERMEDIATE_SETPOINTS_TILT"           type="octet_string" length="254" default="1,0x0000"        optional="true" >IntermediateSetpointsTilt</attribute> -->
     <!-- Conformance feature Optional -->
-    <attribute side="server" writable="false" code="0x001A" define="WC_SAFETY_STATUS"                             type="SafetyStatus" min="0x0000" max="0xFFFF" default="0x0000" optional="true" reportable="true" >SafetyStatus</attribute>
-
+    <attribute side="server" code="0x001A" define="WC_SAFETY_STATUS" type="SafetyStatus" min="0x0000" max="0xFFFF" default="0x0000" optional="true" reportable="true">
+      <description>SafetyStatus</description>
+      <optionalConform/>
+    </attribute>
+    
     <!-- Window Covering Command Set -->
     <!-- Conformance feature M -->
     <command source="client" code="0x00" name="UpOrOpen" optional="false" cli="zcl WindowCovering UpOrOpen">
       <description>Moves window covering to InstalledOpenLimitLift and InstalledOpenLimitTilt</description>
+      <mandatoryConform/>
     </command>
     <command source="client" code="0x01" name="DownOrClose" optional="false" cli="zcl WindowCovering DownOrClose">
       <description>Moves window covering to InstalledClosedLimitLift and InstalledCloseLimitTilt</description>
+      <mandatoryConform/>
     </command>
     <command source="client" code="0x02" name="StopMotion" optional="false" cli="zcl WindowCovering StopMotion">
       <description>Stop any adjusting of window covering</description>
+      <mandatoryConform/>
     </command>
     <!-- Conformance feature [LF & ABS] - for now optional -->
     <command source="client" code="0x04" name="GoToLiftValue" optional="true" cli="zcl WindowCovering GoToLiftValue">
       <description>Go to lift value specified</description>
       <arg name="LiftValue" type="int16u"/>
+      <optionalConform>
+        <andTerm>
+          <feature name="LF"/>
+          <feature name="ABS"/>
+        </andTerm>
+      </optionalConform>
     </command>
     <!-- Conformance feature LF & PA_LF | [LF] - for now optional -->
     <command source="client" code="0x05" name="GoToLiftPercentage" optional="true" cli="zcl WindowCovering GoToLiftPercentage">
       <description>Go to lift percentage specified</description>
       <arg name="LiftPercent100thsValue" type="percent100ths"/>
+      <otherwiseConform>
+        <mandatoryConform>
+          <andTerm>
+            <feature name="LF"/>
+            <feature name="PA_LF"/>
+          </andTerm>
+        </mandatoryConform>
+        <optionalConform>
+          <feature name="LF"/>
+        </optionalConform>
+      </otherwiseConform>
     </command>
     <!-- Conformance feature [TL & ABS] - for now optional -->
     <command source="client" code="0x07" name="GoToTiltValue" optional="true" cli="zcl WindowCovering GoToTiltValue">
       <description>Go to tilt value specified</description>
       <arg name="TiltValue" type="int16u"/>
+      <optionalConform>
+        <andTerm>
+          <feature name="TL"/>
+          <feature name="ABS"/>
+        </andTerm>
+      </optionalConform>
     </command>
     <!-- Conformance feature TL & PA_TL | [TL] - for now optional -->
     <command source="client" code="0x08" name="GoToTiltPercentage" optional="true" cli="zcl WindowCovering GoToTiltPercentage">
       <description>Go to tilt percentage specified</description>
       <arg name="TiltPercent100thsValue" type="percent100ths"/>
+      <otherwiseConform>
+        <mandatoryConform>
+          <andTerm>
+            <feature name="TL"/>
+            <feature name="PA_TL"/>
+          </andTerm>
+        </mandatoryConform>
+        <optionalConform>
+          <feature name="TL"/>
+        </optionalConform>
+      </otherwiseConform>
     </command>
   </cluster>
 


### PR DESCRIPTION
**Description:**
This PR adds conformance data to attributes, commands, and events in ZAP XMLs using automated generation from Alchemy.

**Generation Method:**
Since Alchemy does not provide a command to directly generate conformance, the changes in this PR were produced by generating the diff between running Alchemy commands with and without the conformance flag. As a result, some unrelated changes are also included: Alchemy removes attributes with default values inside `<attribute>` tags. They are redundant and will not affect XML parsing. For example: `optional="false"` and `min="0"` (for unsigned int types) are omitted.

**Validation and Discoveries:**
To validate the generation result, Paul and I spent an entire day on reviewing and comparing all conformance-related updates against the spec element by element to ensure accuracy. Here are key findings:

1. Conformance data for elements within the cluster extension of `color-control-cluster.xml` was not generated by Alchemy and has been manually added based on the spec.
2. An empty conformance field in the spec is translated into `mandatoryConform` in XML.
3. If the conformance field is `desc` in the spec, no conformance will be added to the XML. When combined with other conformance types, for example, `P, desc`, it translates to a `provisionalConform` inside `otherwiseConform`, and `desc` translates to nothing. It is wrong and should just be `provisionalConform`



